### PR TITLE
DOCKER-DEV: Add arm64 glibc headers from #606 and other refactors

### DIFF
--- a/DOCKER-DEV.md
+++ b/DOCKER-DEV.md
@@ -42,7 +42,7 @@ Clone `lbry-android`:
 ```
 LBRY_GIT=$HOME/git/vendor/lbryio/
 mkdir -p $LBRY_GIT
-git clone https://github.com/lbryio/lbry-android.git $LBRY_GIT
+git clone https://github.com/lbryio/lbry-android.git $LBRY_GIT/lbry-android
 cd $LBRY_GIT/lbry-android
 git submodule update --init --recursive
 ```

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -24,4 +24,5 @@ exe mkdir -p $BUILDOZER_HOME/android/crystax-ndk-10.3.2/build/tools/
 exe mkdir -p $BUILDOZER_HOME/android/crystax-ndk-10.3.2/platforms/android-21/arch-arm/usr/include/crystax/bionic/libc/include/sys/
 exe cp /src/scripts/build-target-python.sh ~/.buildozer/android/crystax-ndk-10.3.2/build/tools/build-target-python.sh
 exe cp /src/scripts/mangled-glibc-syscalls.h ~/.buildozer/android/crystax-ndk-10.3.2/platforms/android-21/arch-arm/usr/include/crystax/bionic/libc/include/sys/mangled-glibc-syscalls.h
+exe cp /src/scripts/mangled-glibc-syscalls__arm64.h ~/.buildozer/android/crystax-ndk-10.3.2/platforms/android-21/arch-arm64/usr/include/crystax/bionic/libc/include/sys/mangled-glibc-syscalls.h
 exe mv $BUILDOZER_HOME/android/platform/android-sdk-23/build-tools/android-8.1.0 $BUILDOZER_HOME/android/platform/android-sdk-23/build-tools/26.0.2

--- a/scripts/lbry-android.sh
+++ b/scripts/lbry-android.sh
@@ -58,7 +58,8 @@
         exe $HOME/Android/Sdk/tools/bin/sdkmanager "platforms;android-27"
         if [ -d $LBRY_ANDROID_BUILDOZER_HOME ]; then
             echo "Buildozer path already exists: $LBRY_ANDROID_BUILDOZER_HOME"
-            echo "If you would like to re-install from scratch, delete that directory first."
+            echo "If you would like to re-install from scratch, delete that directory first:"
+            echo "    sudo rm -rf $LBRY_ANDROID_BUILDOZER_HOME"
         else
             mkdir -p $LBRY_ANDROID_BUILDOZER_HOME
             mkdir -p $LBRY_ANDROID_BUILDOZER_DOWNLOADS
@@ -118,7 +119,16 @@
         fi
     }
 
-    SUBCOMMANDS_NO_ARGS=(setup clone docker-build build)
+    clean() {
+        exe sudo docker run --rm -it \
+            -v $LBRY_ANDROID_HOME:/src \
+            -v $LBRY_ANDROID_BUILDOZER_HOME:/home/lbry-android/.buildozer/ \
+            -v $LBRY_ANDROID_HOME/.gradle:/home/lbry-android/.gradle/ \
+            -v $ANDROID_SDK_LICENSE:/home/lbry-android/.buildozer/android/platform/android-sdk-23/licenses/android-sdk-license \
+            $LBRY_ANDROID_IMAGE /bin/bash -c "cd /src && buildozer android clean"
+    }
+
+    SUBCOMMANDS_NO_ARGS=(setup clone docker-build build clean)
     SUBCOMMANDS_PASS_ARGS=(none)
 
     check-dependencies || return 1


### PR DESCRIPTION
Needs pinned dependency: "rn-fetch-blob": "0.10.15"

Otherwise you will get:

```
error: package androidx.core.content does not exist
```