### PR TITLE
Fix minor typo for string in 'generate_address_hint'.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,7 +174,7 @@
     <string name="receive_credits">Receive Credits</string>
     <string name="use_this_address_hint">Use this wallet address to receive credits sent by another user (or yourself).</string>
     <string name="get_new_address">Get new address</string>
-    <string name="generate_address_hint">You can generate a new address at any time, and any previous addresses will conintue to work. Using multiple addresses can be helpful for keeping track of incoming payments from multiple sources.</string>
+    <string name="generate_address_hint">You can generate a new address at any time, and any previous addresses will continue to work. Using multiple addresses can be helpful for keeping track of incoming payments from multiple sources.</string>
 
     <string name="send_credits">Send Credits</string>
     <string name="recipient_address">Recipient address</string>


### PR DESCRIPTION
Fixes minor spelling typo.

Since it's just a typo for this specific case (no change in ID or sentence structure), it wouldn't matter much to the translators.

For future reference:  What I'm not sure if how this will get propagated to the translators.  If a change is made in this file, will it get published to them nightly?  Will major changes be automatically marked as "require re-translation"?

