### PR TITLE
Only send comment tip if comment was successfully created

### DIFF
--- a/app/src/main/java/io/lbry/browser/tasks/CommentCreateWithTipTask.java
+++ b/app/src/main/java/io/lbry/browser/tasks/CommentCreateWithTipTask.java
@@ -62,13 +62,6 @@ public class CommentCreateWithTipTask extends AsyncTask<Void, Void, Comment> {
             }
 
             Map<String, Object> options = new HashMap<>();
-            options.put("blocking", true);
-            options.put("claim_id", comment.getClaimId());
-            options.put("amount", new DecimalFormat(Helper.SDK_AMOUNT_FORMAT, new DecimalFormatSymbols(Locale.US)).format(amount.doubleValue()));
-            options.put("tip", true);
-            Lbry.genericApiCall(Lbry.METHOD_SUPPORT_CREATE, options);
-
-            options = new HashMap<>();
             options.put("comment", comment.getText());
             options.put("claim_id", comment.getClaimId());
             options.put("channel_id", comment.getChannelId());
@@ -78,6 +71,14 @@ public class CommentCreateWithTipTask extends AsyncTask<Void, Void, Comment> {
             }
             JSONObject jsonObject = (JSONObject) Lbry.genericApiCall(Lbry.METHOD_COMMENT_CREATE, options);
             createdComment = Comment.fromJSONObject(jsonObject);
+            if (createdComment != null) {
+                options = new HashMap<>();
+                options.put("blocking", true);
+                options.put("claim_id", comment.getClaimId());
+                options.put("amount", new DecimalFormat(Helper.SDK_AMOUNT_FORMAT, new DecimalFormatSymbols(Locale.US)).format(amount.doubleValue()));
+                options.put("tip", true);
+                Lbry.genericApiCall(Lbry.METHOD_SUPPORT_CREATE, options);
+            }
         } catch (ApiCallException | ClassCastException | IOException | JSONException ex) {
             error = ex;
         }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: fixes #945 

## What is the current behavior?
If a comment fails to be created, a tip of 1 LBC is still sent to the creator.

## What is the new behavior?
If a comment fails to be created, a tip is not sent to the creator.
