### PR TITLE
Bintray repository is no longer needed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ allprojects {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
-        maven { url  "https://dl.bintray.com/lbryio/io.lbry" }
     }
 }
 


### PR DESCRIPTION
LBRY SDK is now hosted on JCenter, which is already available out-of-the-box on Android Studio. The Bintray url is no longer reguired. When building LBRY on F-Droid, I have to remove this line on the build YAML script and it is building correctly.

On my local machine, Android Studio directly builds the app after removing it.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: Trivial removal of not required step

## Fixes

Issue Number:

## What is the current behavior?

Use certain library repository

## What is the new behavior?

Don't use it as the required one is already integrated into the toolchain.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
