### PR TITLE
Add open.lbry.com deep-links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,13 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="lbry" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="https" android:host="open.lbry.com"/>
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
 PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #957 

## What is the current behavior?
LBRY Android is not offered when user clicks on open.lbry.com links.

## What is the new behavior?
LBRY Android will show on lists of apps which can manage open.lbry.com links
## Other information
It adds itself for intents with an '`https://`" protocol schema and an '`open.lbry.com`' host on AndroidManifest.

When system observes an intent from user to visit any link of the form `https://open.lbry.com:`, it will show a dialog with a list of all apps registered for that intent. When user selects LBRY app, the system will open it and it will recieve the link, which this PR will transform into something like an lbry:// intent, instead of managing it separatelly.

It modifies regex parts as following:

* Add 'https' as a possible option for protocol part
* Add a HOST regex part which could only be empty or open.lbry.com

It shifts components for matched strings as a new host component has been added.

In case host part is the expected 'open.lbry.com', it will change separators from ':' to '#'. This is also commented on code.

### Note for merger
Maybe this PR could be delayed for next 0.16 release or even a future one as it adds a new feature and not a bug-fix. Until then, I will be attending any change requested by the reviewer.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
