### PR TITLE
Allow to publish files via Send To feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,13 @@
             </intent-filter>
 
             <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="video/*" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -8,6 +8,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.PictureInPictureParams;
 import android.content.BroadcastReceiver;
+import android.content.ClipData;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -579,6 +580,7 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
 
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        checkSendToIntent(intent);
         checkUrlIntent(intent);
         checkNotificationOpenIntent(intent);
     }
@@ -831,6 +833,12 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
         Map<String, Object> params = new HashMap<>();
         params.put("url", url);
         openFragment(FileViewFragment.class, true, NavMenuItem.ID_ITEM_FOLLOWING, params);
+    }
+
+    public void openSendTo(String path) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("directFilePath", path);
+        openFragment(PublishFormFragment.class, true, NavMenuItem.ID_ITEM_NEW_PUBLISH, params);
     }
 
     public void openFileClaim(Claim claim) {
@@ -2642,6 +2650,19 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
         Bundle bundle = new Bundle();
         bundle.putString("name", name);
         LbryAnalytics.logEvent(LbryAnalytics.EVENT_LBRY_NOTIFICATION_OPEN, bundle);
+    }
+
+    private void checkSendToIntent(Intent intent) {
+        String intentAction = intent.getAction();
+        if (intentAction != null && intentAction.equals("android.intent.action.SEND")) {
+            ClipData clipData = intent.getClipData();
+            if (clipData != null) {
+                Uri uri = clipData.getItemAt(0).getUri();
+
+                String path = Helper.getRealPathFromURI_API19(this, uri);
+                openSendTo(path);
+            }
+        }
     }
 
     private void registerServiceActionsReceiver() {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 660

## What is the current behavior?
LBRY Android is not shown on Send To list of apps
## What is the new behavior?
LBRY Android will be shown when user wanted to share (=send) a video/image/text file. Then user could publish the file as if it had selected the file from the file picker.
## Other information
Sorry for previous cancelled PR. I had to sync the branch with master one. This PR is not intended to do the same for files stored "on the cloud", although it could also improve the experience for those users.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
