### PR TITLE
Add setting to enable sending buffering events

### DIFF
--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -311,6 +311,7 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
     public static final String PREFERENCE_KEY_NOTIFICATION_CREATOR = "io.lbry.browser.preference.notifications.Creator";
     public static final String PREFERENCE_KEY_KEEP_SDK_BACKGROUND = "io.lbry.browser.preference.other.KeepSdkInBackground";
     public static final String PREFERENCE_KEY_PARTICIPATE_DATA_NETWORK = "io.lbry.browser.preference.other.ParticipateInDataNetwork";
+    public static final String PREFERENCE_KEY_SEND_BUFFERING_EVENTS = "io.lbry.browser.preference.other.SendBufferingEvents";
 
     // Internal flags / setting preferences
     public static final String PREFERENCE_KEY_INTERNAL_SKIP_WALLET_ACCOUNT = "io.lbry.browser.preference.internal.WalletSkipAccount";

--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -298,7 +298,15 @@ public class FileViewFragment extends BaseFragment implements
                         loadingNewClaim = false;
                     }
                 } else if (playbackState == Player.STATE_BUFFERING) {
-                    if (MainActivity.appPlayer != null && MainActivity.appPlayer.getCurrentPosition() > 0) {
+                    Context ctx = getContext();
+                    boolean sendBufferingEvents = false;
+
+                    if (ctx != null) {
+                        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);
+                        sendBufferingEvents = sp.getBoolean(MainActivity.PREFERENCE_KEY_SEND_BUFFERING_EVENTS, true);
+                    }
+
+                    if (MainActivity.appPlayer != null && MainActivity.appPlayer.getCurrentPosition() > 0 && sendBufferingEvents) {
                         // we only want to log a buffer event after the media has already started playing
                         String mediaSourceUrl = getStreamingUrl();
                         long duration = MainActivity.appPlayer.getDuration();

--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -299,7 +299,7 @@ public class FileViewFragment extends BaseFragment implements
                     }
                 } else if (playbackState == Player.STATE_BUFFERING) {
                     Context ctx = getContext();
-                    boolean sendBufferingEvents = false;
+                    boolean sendBufferingEvents = true;
 
                     if (ctx != null) {
                         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@
 
     <string name="keep_sdk_in_background">Keep the LBRY service running in the background for improved wallet and network performance</string>
     <string name="participate_in_data_network">Participate in the data network (requires app and background service restart)</string>
+    <string name="send_buffering_events">Send buffering events to LBRY servers</string>
 
     <!-- URL suggestions -->
     <string name="search_url_title">%1$s - Search</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -64,5 +64,11 @@
             app:title="@string/participate_in_data_network"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
+        <SwitchPreferenceCompat
+            app:key="io.lbry.browser.preference.other.SendBufferingEvents"
+            app:title="@string/send_buffering_events"
+            app:defaultValue="true"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
Buffering events are sent to LBRY without user permission. User cannot disable this behavior. This makes Tracking AntiFeature to appear in FDroid store listing.
## What is the new behavior?
No buffering event is sent to LBRY servers by default. User can enable this events to be sent at will. FDroid will not show the Tracking AntiFeature as user is in control of data being sent and the default is to not send it.
## Other information
This is a change required to remove the Tracking AntiFeature from FDroid listing. This PR adds the Preference to upstream lbry-android with a default 'true' value. Then FDroid build script will change default to 'false' so no data is sent by default on the APK built by FDroid.

Translation on 1 new string will be required. Of course it could be reworded if LBRY teams requires it.

Any required change to the PR, just ask for it and I will commit a new rebased PR.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->