### PR TITLE
Support some lbry hosts to deep links. Add unit tests

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,10 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data android:scheme="https" android:host="open.lbry.com"/>
+                <data android:scheme="https" android:host="lbry.tv"/>
+                <data android:scheme="https" android:host="lbry.lat"/>
+                <data android:scheme="https" android:host="lbry.fr"/>
+                <data android:scheme="https" android:host="lbry.in"/>
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/app/src/main/java/io/lbry/browser/utils/LbryUri.java
+++ b/app/src/main/java/io/lbry/browser/utils/LbryUri.java
@@ -18,7 +18,7 @@ public class LbryUri {
     public static final int CLAIM_ID_MAX_LENGTH = 40;
 
     private static final String REGEX_PART_PROTOCOL = "^((?:lbry://|https://)?)";
-    private static final String REGEX_PART_HOST = "((?:open.lbry.com/)?)";
+    private static final String REGEX_PART_HOST = "((?:open.lbry.com/|lbry.tv/|lbry.lat/|lbry.fr/|lbry.in/)?)";
     private static final String REGEX_PART_STREAM_OR_CHANNEL_NAME = "([^:$#/]*)";
     private static final String REGEX_PART_MODIFIER_SEPARATOR = "([:$#]?)([^/]*)";
     private static final String QUERY_STRING_BREAKER = "^([\\S]+)([?][\\S]*)";
@@ -128,9 +128,14 @@ public class LbryUri {
         boolean isChannel = includesChannel && Helper.isNullOrEmpty(possibleStreamName);
         String channelName = includesChannel && streamOrChannelName.length() > 1 ? streamOrChannelName.substring(1) : null;
 
-        // It would have thrown already on the RegEx parser if protocol value was incorrect
-        // open.lbry.com uses ':' as ModSeparators while lbry:// expects '#'
-        if (components.get(1).equals("open.lbry.com/")) {
+        /*
+         * It would have thrown already on the RegEx parser if protocol value was incorrect
+         * or HTTPS host was unknown to us.
+         *
+         * [https://] hosts use ':' as ModSeparators while [lbry://] protocol expects '#'
+         */
+
+        if (!components.get(1).isEmpty()) {
             if (primaryModSeparator.equals(":"))
                 primaryModSeparator = "#";
             if (secondaryModSeparator.equals(":"))

--- a/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
+++ b/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
@@ -81,4 +81,28 @@ public class LbryUriTest {
 
         assertEquals(expected, obtained);
     }
+
+    @Test
+    public void parseLbryProtocolOnlyChannel() {
+        LbryUri expectedForChannel = new LbryUri();
+        expectedForChannel.setChannelName("@UCBerkeley");
+        expectedForChannel.setChannel(true);
+
+        try {
+            LbryUri.UriModifier primaryMod = LbryUri.UriModifier.parse("#", "d");
+            expectedForChannel.setChannelClaimId(primaryMod.getClaimId());
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+
+        LbryUri obtained = new LbryUri();
+
+        try {
+            obtained = LbryUri.parse("lbry://@UCBerkeley#d",false);
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(expectedForChannel, obtained);
+    }
 }

--- a/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
+++ b/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
@@ -1,0 +1,84 @@
+package io.lbry.browser.utils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.lbry.browser.exceptions.LbryUriException;
+
+import static org.junit.Assert.assertEquals;
+
+public class LbryUriTest {
+    private LbryUri expected;
+
+    /*
+     * Create an LbryUri object and assign fields manually using class methods. This object will be
+     * compared with LbryUri.parse() returned object on each test.
+     */
+    @Before
+    public void createExpected() {
+        expected = new LbryUri();
+        expected.setChannelName("@lbry");
+        expected.setStreamName("lbryturns4");
+
+        try {
+            LbryUri.UriModifier primaryMod = LbryUri.UriModifier.parse("#", "3f");
+            LbryUri.UriModifier secondaryMod = LbryUri.UriModifier.parse("#", "6");
+            expected.setChannelClaimId(primaryMod.getClaimId());
+            expected.setStreamClaimId(secondaryMod.getClaimId());
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void parseOpenLbryComWithChannel() {
+        LbryUri obtained = new LbryUri();
+
+        try {
+            obtained = LbryUri.parse("https://open.lbry.com/@lbry:3f/lbryturns4:6",false);
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(expected, obtained);
+    }
+
+    @Test
+    public void parseLbryTvWithChannel() {
+        LbryUri obtained = new LbryUri();
+
+        try {
+            obtained = LbryUri.parse("https://lbry.tv/@lbry:3f/lbryturns4:6",false);
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(expected, obtained);
+    }
+
+    @Test
+    public void parseLbryAlterWithChannel() {
+        LbryUri obtained = new LbryUri();
+
+        try {
+            obtained = LbryUri.parse("https://lbry.lat/@lbry:3f/lbryturns4:6",false);
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(expected, obtained);
+    }
+
+    @Test
+    public void parseLbryProtocolWithChannel() {
+        LbryUri obtained = new LbryUri();
+
+        try {
+            obtained = LbryUri.parse("lbry://@lbry#3f/lbryturns4#6",false);
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(expected, obtained);
+    }
+}

--- a/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
+++ b/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
@@ -1,5 +1,6 @@
 package io.lbry.browser.utils;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -84,16 +85,7 @@ public class LbryUriTest {
 
     @Test
     public void parseLbryProtocolOnlyChannel() {
-        LbryUri expectedForChannel = new LbryUri();
-        expectedForChannel.setChannelName("@UCBerkeley");
-        expectedForChannel.setChannel(true);
-
-        try {
-            LbryUri.UriModifier primaryMod = LbryUri.UriModifier.parse("#", "d");
-            expectedForChannel.setChannelClaimId(primaryMod.getClaimId());
-        } catch (LbryUriException e) {
-            e.printStackTrace();
-        }
+        LbryUri expectedForChannel = sinthesizeExpected();
 
         LbryUri obtained = new LbryUri();
 
@@ -104,5 +96,35 @@ public class LbryUriTest {
         }
 
         assertEquals(expectedForChannel, obtained);
+    }
+
+    @Test
+    public void parseLbryTvProtocolOnlyChannel() {
+        LbryUri expectedForChannel = sinthesizeExpected();
+
+        LbryUri obtained = new LbryUri();
+
+        try {
+            obtained = LbryUri.parse("https://lbry.tv/@UCBerkeley:d",false);
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(expectedForChannel, obtained);
+    }
+
+    @NotNull
+    private LbryUri sinthesizeExpected() {
+        LbryUri expectedForChannel = new LbryUri();
+        expectedForChannel.setChannelName("@UCBerkeley");
+        expectedForChannel.setChannel(true);
+
+        try {
+            LbryUri.UriModifier primaryMod = LbryUri.UriModifier.parse("#", "d");
+            expectedForChannel.setChannelClaimId(primaryMod.getClaimId());
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+        return expectedForChannel;
     }
 }


### PR DESCRIPTION
…sts for LbryUri parse() method

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: Unit Tests

## Fixes

Issue Number:

## What is the current behavior?
LBRY.TV and other links are not captured by LBRY Android when clicked on other apps
## What is the new behavior?
LBRY Android will be offered to users when they click on any LBRY.[TV|LAT|IN|FR] hosted link.
## Other information
Furthermore, I have also added unit tests for the LbryUri.parse(String, bool) method. In order to run them, it could be required to edit the 'Shorten command line' configuration and change the value to 'JAR Manifest', which was the one I used to run them.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
