### PR TITLE
Add ability to download & delete your own videos and move unpublish button to description

### DIFF
--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -1010,30 +1010,39 @@ public class FileViewFragment extends BaseFragment implements
                 }
 
                 if (claim != null) {
-                    boolean isOwnClaim = Lbry.ownClaims.contains(claim);
-                    if (isOwnClaim) {
-                        AlertDialog.Builder builder = new AlertDialog.Builder(getContext()).
-                                setTitle(R.string.delete_content).
-                                setMessage(R.string.confirm_delete_content_message)
-                                .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialogInterface, int i) {
-                                        deleteCurrentClaim();
-                                    }
-                                }).setNegativeButton(R.string.no, null);
-                        builder.show();
-                    } else {
-                        AlertDialog.Builder builder = new AlertDialog.Builder(getContext()).
-                                setTitle(R.string.delete_file).
-                                setMessage(R.string.confirm_delete_file_message)
-                                .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialogInterface, int i) {
-                                        deleteClaimFile();
-                                    }
-                                }).setNegativeButton(R.string.no, null);
-                        builder.show();
-                    }
+                    AlertDialog.Builder builder = new AlertDialog.Builder(getContext()).
+                        setTitle(R.string.delete_file).
+                        setMessage(R.string.confirm_delete_file_message)
+                        .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                deleteClaimFile();
+                            }
+                        }).setNegativeButton(R.string.no, null);
+                    builder.show();
+                }
+            }
+        });
+
+        root.findViewById(R.id.file_view_action_unpublish).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (!Lbry.SDK_READY) {
+                    Snackbar.make(root.findViewById(R.id.file_view_claim_display_area), R.string.sdk_initializing_functionality, Snackbar.LENGTH_LONG).show();
+                    return;
+                }
+
+                if (claim != null) {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(getContext()).
+                        setTitle(R.string.delete_content).
+                        setMessage(R.string.confirm_delete_content_message)
+                        .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                deleteCurrentClaim();
+                            }
+                        }).setNegativeButton(R.string.no, null);
+                    builder.show();
                 }
             }
         });
@@ -2773,10 +2782,9 @@ public class FileViewFragment extends BaseFragment implements
             boolean isOwnClaim = Lbry.ownClaims.contains(claim);
             View root = getView();
             if (root != null) {
-                Helper.setViewVisibility(root.findViewById(R.id.file_view_action_download), isOwnClaim ? View.GONE : View.VISIBLE);
                 Helper.setViewVisibility(root.findViewById(R.id.file_view_action_report), isOwnClaim ? View.GONE : View.VISIBLE);
                 Helper.setViewVisibility(root.findViewById(R.id.file_view_action_edit), isOwnClaim ? View.VISIBLE : View.GONE);
-                Helper.setViewVisibility(root.findViewById(R.id.file_view_action_delete), isOwnClaim ? View.VISIBLE : View.GONE);
+                Helper.setViewVisibility(root.findViewById(R.id.file_view_action_unpublish), isOwnClaim ? View.VISIBLE : View.GONE);
             }
         }
     }

--- a/app/src/main/res/drawable-anydpi/ic_unpublish.xml
+++ b/app/src/main/res/drawable-anydpi/ic_unpublish.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF"
+    android:alpha="0.8">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M5,3h14v2h-14zM9,7v6h-4l7,7l7,-7h-4v-6"/>
+</vector>

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/file_view_global_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -578,52 +579,63 @@
 
                 <LinearLayout
                     android:id="@+id/file_view_description_area"
-                    android:orientation="vertical"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:orientation="vertical"
                     android:visibility="gone">
+
                     <TextView
                         android:id="@+id/file_view_description"
-                        android:textSize="12sp"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:fontFamily="@font/inter"
+                        android:layout_marginStart="16dp"
+                        android:layout_marginEnd="16dp"
                         android:autoLink="all"
+                        android:fontFamily="@font/inter"
                         android:textColorLink="@color/lbryGreen"
                         android:textFontWeight="300"
-                        android:layout_marginStart="16dp"
-                        android:layout_marginEnd="16dp" />
+                        android:textSize="12sp" />
+
                     <LinearLayout
                         android:id="@+id/file_view_tag_area"
-                        android:orientation="horizontal"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="10"
-                        android:paddingTop="36dp"
                         android:layout_marginStart="16dp"
-                        android:layout_marginEnd="16dp">
+                        android:layout_marginEnd="16dp"
+                        android:layout_weight="10"
+                        android:orientation="horizontal"
+                        android:paddingTop="36dp">
+
                         <TextView
-                            android:layout_weight="2"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
+                            android:layout_weight="2"
                             android:fontFamily="@font/inter"
                             android:text="@string/tags"
-                            android:textSize="12sp"
-                            android:textFontWeight="600" />
+                            android:textFontWeight="600"
+                            android:textSize="12sp" />
+
                         <androidx.recyclerview.widget.RecyclerView
                             android:id="@+id/file_view_tag_list"
-                            android:layout_weight="8"
-                            android:layout_marginStart="8dp"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content" />
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:layout_weight="8" />
                     </LinearLayout>
 
+                    <Button
+                        android:id="@+id/file_view_action_unpublish"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/unpublish"
+                        app:icon="@drawable/ic_unpublish" />
+
                     <View
-                        android:background="@color/divider"
                         android:layout_width="match_parent"
+                        android:layout_height="0.5dp"
                         android:layout_marginTop="12dp"
                         android:layout_marginBottom="12dp"
-                        android:layout_height="0.5dp" />
+                        android:background="@color/divider" />
                 </LinearLayout>
 
                 <LinearLayout
@@ -751,4 +763,5 @@
         android:visibility="gone">
 
     </RelativeLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,7 @@
     <string name="receive">Receive</string>
     <string name="spend">Spend</string>
     <string name="publish">Publish</string>
+    <string name="unpublish">Unpublish</string>
     <string name="support">Support</string>
     <string name="abandon">Abandon</string>
     <string name="channel">Channel</string>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #987 

## What is the current behavior?
Inability to download your own videos.

## What is the new behavior?
The ability to download new videos. Due to the old reuse of the delete action for both deleting from files and unpublishing, a distinction had to be made if both were to be possible. So, I put an unpublish button in the description (since it wouldn't fit in the current actions area) and removed the ability to unpublish from the old delete button.