### PR TITLE
Fix issue #1012

### DIFF
--- a/app/src/main/java/io/lbry/browser/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/io/lbry/browser/adapter/ClaimListAdapter.java
@@ -430,7 +430,6 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         Helper.setViewVisibility(vh.loadingTextPlaceholder2, item.isLoadingPlaceholder() ? View.VISIBLE : View.GONE);
         Helper.setViewVisibility(vh.titleView, !item.isLoadingPlaceholder() ? View.VISIBLE : View.GONE);
         Helper.setViewVisibility(vh.publisherView, !item.isLoadingPlaceholder() ? View.VISIBLE : View.GONE);
-        Helper.setViewVisibility(vh.publishTimeView, !item.isLoadingPlaceholder() ? View.VISIBLE : View.GONE);
 
         if (type == VIEW_TYPE_FEATURED && item.isUnresolved()) {
             vh.durationView.setVisibility(View.GONE);


### PR DESCRIPTION
Visibility of "Pending" and the publish time views is set only once
in a mutually exclusive way.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 1012

## What is the current behavior?
New content uploaded appears in Claim List with overlapping texts - "Pending"  + publishing time.

## What is the new behavior?
Publishing time stays hidden until the claim is not in a pending state

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
