### PR TITLE
Fix issue #1025

### DIFF
--- a/app/src/main/res/layout/fragment_publish_form.xml
+++ b/app/src/main/res/layout/fragment_publish_form.xml
@@ -316,7 +316,7 @@
                             <androidx.appcompat.widget.AppCompatSpinner
                                 android:id="@+id/publish_form_currency_spinner"
                                 android:entries="@array/publish_currencies"
-                                android:layout_width="110dp"
+                                android:layout_width="160dp"
                                 android:layout_height="wrap_content"
                                 android:layout_toEndOf="@+id/publish_form_price_layout"
                                 android:layout_marginStart="4dp"


### PR DESCRIPTION
Increased size of currency selection spinner in publish form fragment
Now spinner is in proper size to display "LBRY Credits" default value

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes
Layout issue in publishing form fragment - currency selection spinner 
inside Price section (when Price is toggled on)
now big enough to display default currency "LBRY Credits"
(Increased spinner width)

Issue Number: 1025

## What is the current behavior?
Currency selection spinner shows truncated string "LBRY .."
instead of the full default value "LBRY Credits"

## What is the new behavior?
Currency selection spinner now displaying the full "LBRY Credits" value

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
