### PR TITLE
Fix issue #1030

### DIFF
--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -92,6 +92,7 @@ import androidx.core.view.GravityCompat;
 import androidx.core.view.OnApplyWindowInsetsListener;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
@@ -1032,6 +1033,7 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
         //findViewById(R.id.global_sdk_initializing_status).setVisibility(View.GONE);
         findViewById(R.id.app_bar_main_container).setFitsSystemWindows(true);
         hideActionBar();
+        dismissActiveDialogs();
 
         for (PIPModeListener listener : pipModeListeners) {
             listener.onEnterPIPMode();
@@ -1044,6 +1046,15 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
         pipPlayerContainer.setVisibility(View.VISIBLE);
         playerReassigned = true;
     }
+
+    private void dismissActiveDialogs() {
+        for( Fragment fragment: getSupportFragmentManager().getFragments() ){
+            if (fragment instanceof DialogFragment){
+                ((DialogFragment) fragment).dismiss();
+            }
+        }
+    }
+
     private void renderFullMode() {
         if (!inFullscreenMode) {
             showActionBar();


### PR DESCRIPTION
Dismiss all active dialog fragment when entering PiP mode
So that PiP window contain the video only

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 1030

## What is the current behavior?
Support/Repost dialogs interfere with video displayed in PiP mode

## What is the new behavior?
When entering PiP mode - any unfinished dialogs are dismissed, 
leaving the PiP clean of any unrelated artifacts 

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
