### PR TITLE
Fix for text not rendering after # in markdown

### DIFF
--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -92,6 +92,8 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.lbry.browser.MainActivity;
 import io.lbry.browser.R;
@@ -2072,7 +2074,17 @@ public class FileViewFragment extends BaseFragment implements
             @Override
             public void onSuccess(String text) {
                 String html = buildMarkdownHtml(text);
+
                 if (webView != null) {
+                    // Due to a change to Chrome, WebView only displays '#' -and everything after it-
+                    // if it is '%23' instead. Problem appears in text like '#2' or #hashtags.
+                    Pattern pattern = Pattern.compile("#(\\S+)");
+                    Matcher matcher = pattern.matcher(html);
+
+                    if (matcher.find()) {
+                        html = html.replaceAll(pattern.toString(), "&%2335;" + matcher.group(1));
+                    }
+
                     webView.loadData(html, "text/html", "utf-8");
                 }
             }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #960 (partial fix, do not close it)

## What is the current behavior?
Due to some change introduced in Chrome, WebViews are unable to render anything after the first '#'. If that happens at the beginning of the markdown document, the HTML render will not be displayed, although the HTML code itself is correct.

Strings like '#1', '#hashtag' will make the problem appear.
## What is the new behavior?
This fix changes the '#' into '%23' on the HTML generated code from markdown.
## Other information
The issue indicated above was about two distincts problems. This one fixes the one from the German blog post. That file was modified, so it is no longer showing the problem. However, it was identified as being related to '#'.

The other one was about lbrycast style of claims, where video was embedded into the markdown using an IFRAME. I will also try to fix that in some future PR.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
