### PR TITLE
Fix issue #1034

### DIFF
--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -1032,6 +1032,7 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
         findViewById(R.id.global_now_playing_card).setVisibility(View.GONE);
         //findViewById(R.id.global_sdk_initializing_status).setVisibility(View.GONE);
         findViewById(R.id.app_bar_main_container).setFitsSystemWindows(true);
+        hideNotifications();
         hideActionBar();
         dismissActiveDialogs();
 


### PR DESCRIPTION
Hide notifications when entering PiP mode

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 1034

## What is the current behavior?
Notifications container remain visible when entering PiP mode , blocking video

## What is the new behavior?
Video visible
Notifications get hidden when entering PiP mode

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
