### PR TITLE
fix issue 1038

### DIFF
--- a/app/src/main/res/layout/list_item_transaction.xml
+++ b/app/src/main/res/layout/list_item_transaction.xml
@@ -26,7 +26,7 @@
             />
         <TextView
             android:id="@+id/transaction_amount"
-            android:gravity="right"
+            android:gravity="end"
             android:layout_weight="4"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -60,7 +60,7 @@
             />
         <TextView
             android:id="@+id/transaction_fee"
-            android:gravity="right"
+            android:gravity="end"
             android:layout_weight="4"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -90,10 +90,11 @@
             android:textColor="@color/lbryGreen"
             android:textSize="12sp"
             android:textFontWeight="300"
+            android:textAlignment="viewStart"
             />
         <TextView
             android:id="@+id/transaction_date"
-            android:gravity="right"
+            android:gravity="end"
             android:layout_weight="4"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -106,7 +107,7 @@
             android:visibility="gone" />
         <TextView
             android:id="@+id/transaction_pending_text"
-            android:gravity="right"
+            android:gravity="end"
             android:layout_weight="4"
             android:layout_width="0dp"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Replaced gravity pinning to "end" instead of "right"
Pinned claim id which could be in rtl and ltr scripts to the start of the layout

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 1038

## What is the current behavior?
Claim ID misaligned with transaction description in Recent Transaction/T. History

## What is the new behavior?
Claim ID aligned with transaction description

## Screenshots
![claim_id_rtl_fixed](https://user-images.githubusercontent.com/33922624/96307211-ea80ed00-1009-11eb-9227-0cb27a8e0caa.png)



<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
