### PR TITLE
fix issue 1040

### DIFF
--- a/app/src/main/res/layout/list_item_transaction.xml
+++ b/app/src/main/res/layout/list_item_transaction.xml
@@ -26,7 +26,7 @@
             />
         <TextView
             android:id="@+id/transaction_amount"
-            android:gravity="right"
+            android:gravity="end"
             android:layout_weight="4"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -34,7 +34,9 @@
             android:fontFamily="@font/inter"
             android:singleLine="true"
             android:textSize="14sp"
-            android:textFontWeight="300" />
+            android:textFontWeight="300"
+            android:textAlignment="viewEnd"
+            android:textDirection="ltr"/>
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
Transaction amount text Direction changed to LTR.
Transaction amount pinned to end of view

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 1040

## What is the current behavior?
RTL layouts displaying negative transaction amounts with misplaced sign as (amount)(minus)

## What is the new behavior?
RTL layouts displaying negative transaction amounts as (minus)(amount)

## Screenshots

### LTR layout after fix

Stable - not modifed
![negative_amount_fix_ltr](https://user-images.githubusercontent.com/33922624/96352672-a6efb700-10cd-11eb-975c-57f11d840a4a.jpg)

### RTL layout afer fix
Fixed
![negative_amount_fix_rtl](https://user-images.githubusercontent.com/33922624/96352702-f635e780-10cd-11eb-927e-dce38180771b.jpg)
(Ignore separate RTL UI issues - further fixes in other PR's)

## Other information
Pure numeric texts should always be LTR text direction

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
