### PR TITLE
Fix floating wallet/rewards bar for RTL layout

### DIFF
--- a/app/src/main/res/layout/floating_wallet_balance.xml
+++ b/app/src/main/res/layout/floating_wallet_balance.xml
@@ -8,7 +8,7 @@
     android:layout_marginBottom="8dp"
     android:layout_marginEnd="8dp"
     android:elevation="4dp"
-    app:layout_constraintRight_toRightOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintBottom_toBottomOf="parent">
     <LinearLayout
         android:id="@+id/floating_reward_container"
@@ -50,7 +50,7 @@
         android:foreground="?attr/selectableItemBackground"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/floating_reward_container"
+        android:layout_toEndOf="@id/floating_reward_container"
         android:layout_marginStart="-36dp"
         android:paddingTop="8dp"
         android:paddingBottom="8dp"


### PR DESCRIPTION
Floating wallet balance/rewards now visible in RTL layout

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #1043 

## What is the current behavior?
Floating wallet fragment pinned to the bottom right of the screen (regardless of layout direction)
 Floating wallet fragment does not display wallet balance on RTL layout

## What is the new behavior?
Floating wallet fragment pinned to the bottom end of the screen - generalized LTR/RTL solution
Floating wallet fragment now displays both rewards and balance

## Screenshots

### LTR layout after fix
Not modified
![bug_floating_fixed_ltr](https://user-images.githubusercontent.com/33922624/96769327-a2860f80-13e7-11eb-95a1-7647040014cb.jpg)


### RTL layout after fix
Fixed
![bug_floating_fixed_rtl](https://user-images.githubusercontent.com/33922624/96769268-8edaa900-13e7-11eb-814f-8c8e40154cdc.jpg)

## Disclaimer 
I swear I'm not splitting every little RTL issue to separate PR's
I'm genuinely finding them one at a time 🤷

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
