### PR TITLE
Offer opening unsupported filetypes with external app

### DIFF
--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -1522,6 +1522,12 @@ public class FileViewFragment extends BaseFragment implements
                     onMainActionButtonClicked();
                 }
             });
+            root.findViewById(R.id.file_view_open_external_button).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    openClaimExternally(claim, claim.getMediaType());
+                }
+            });
 
             if (metadata instanceof Claim.StreamMetadata) {
                 Claim.StreamMetadata streamMetadata = (Claim.StreamMetadata) metadata;
@@ -2069,6 +2075,8 @@ public class FileViewFragment extends BaseFragment implements
                     }
                     handled = true;
                 }
+            } else {
+                openClaimExternally(claim, mediaType);
             }
         }
 
@@ -2153,6 +2161,18 @@ public class FileViewFragment extends BaseFragment implements
                 "            </div>\n" +
                 "          </body>\n" +
                 "        </html>";
+    }
+
+    private void openClaimExternally(Claim claim, String mediaType) {
+        File file = new File(claim.getFile().getDownloadPath());
+        Uri fileUri = Uri.parse(claim.getFile().getDownloadPath());
+
+        Intent intent = new Intent();
+        intent.setAction(Intent.ACTION_VIEW);
+        intent.setDataAndType(fileUri, mediaType.toLowerCase());
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        Intent chooser = Intent.createChooser(intent, getString(R.string.choose_app));
+        startActivityForResult(chooser, 419);
     }
 
     public void showError(String message) {

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -157,6 +157,13 @@
                         android:textFontWeight="300"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/file_view_open_external_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="@font/inter"
+                        android:textSize="14sp"
+                        android:text="@string/open" />
                 </LinearLayout>
             </RelativeLayout>
         </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="please_select_repost_channel">Please select a channel to repost on.</string>
     <string name="reply">Reply</string>
     <string name="replying_to">Replying to %1$s</string>
+    <string name="choose_app">Choose app</string>
     <plurals name="post_and_tip">
         <item quantity="one">Post and tip %1$s credit?</item>
         <item quantity="other">Post and tip %1$s credits?</item>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #419 

## What is the current behavior?
If LBRY doesn't include the capacity of showing the content on the claim, user should download file and search for it on its device and then open it
## What is the new behavior?
User is shown a notice about LBRY inability to show content and a button which allows it to choose a compatible app when clicked.
## Other information
This PR adds a new string and reuses other one.

In order to test it, reviewer could search for "PDF" on LBRY Android and look for one without a time on the snapshot. I used the ones with "UOC" on their title. "UOC PDF" could be a better approach for the search text.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
