### PR TITLE
Use Java String class toUpperCase method to capitalize

### DIFF
--- a/app/src/main/java/io/lbry/browser/ui/findcontent/AllContentFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/AllContentFragment.java
@@ -210,7 +210,7 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
             String tagName = params.get("singleTag").toString();
             singleTagView = true;
             tags = Arrays.asList(tagName);
-            titleView.setText(Helper.capitalize(tagName));
+            titleView.setText(tagName.toUpperCase());
             Helper.setViewVisibility(customizeLink, View.GONE);
         } else {
             singleTagView = false;

--- a/app/src/main/java/io/lbry/browser/utils/Helper.java
+++ b/app/src/main/java/io/lbry/browser/utils/Helper.java
@@ -108,25 +108,6 @@ public final class Helper {
         return String.format("%sx", formatter.format(speed));
     }
 
-    public static String capitalize(String value) {
-        StringBuilder sb = new StringBuilder();
-        boolean capitalizeNext = true;
-        for (char c : value.toCharArray()) {
-            if (c == ' ') {
-                capitalizeNext = true;
-                sb.append(c);
-            } else {
-                if (capitalizeNext) {
-                    sb.append(String.valueOf(c).toUpperCase());
-                } else {
-                    sb.append(c);
-                }
-                capitalizeNext = false;
-            }
-        }
-        return sb.toString();
-    }
-
     public static String join(List<String> list, String delimiter) {
         StringBuilder sb = new StringBuilder();
         String delim = "";


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## What is the current behavior?
Use code which replicates Java String.toUpperCase() method behavior
## What is the new behavior?
Use Java platform code.

Helper.capitalize(String) method was only used in one line, so it has been removed from Helper.java and replaced the method call by caling String.toUpperCase() instead.