### PR TITLE
Sort replies from oldest to newest

### DIFF
--- a/app/src/main/java/io/lbry/browser/model/Comment.java
+++ b/app/src/main/java/io/lbry/browser/model/Comment.java
@@ -11,7 +11,7 @@ import io.lbry.browser.utils.Helper;
 import lombok.Data;
 
 @Data
-public class Comment {
+public class Comment implements Comparable<Comment> {
     public static final double LBC_COST = 1;
     public static final int MAX_LENGTH = 2000;
 
@@ -65,5 +65,10 @@ public class Comment {
         } catch (JSONException ex) {
             return null;
         }
+    }
+
+    @Override
+    public int compareTo(Comment comment) {
+        return (int)(this.getTimestamp() - comment.getTimestamp());
     }
 }

--- a/app/src/main/java/io/lbry/browser/tasks/CommentListTask.java
+++ b/app/src/main/java/io/lbry/browser/tasks/CommentListTask.java
@@ -8,6 +8,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,9 @@ public class CommentListTask extends AsyncTask<Void, Void, List<Comment>> {
                     }
                 }
             }
+
+            // Sort all replies from oldest to newest at once
+            Collections.sort(children);
 
             for (Comment child : children) {
                 for (Comment parent : comments) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue  Number: #948 

## What is the current behavior?
Replies to comments are ordered in a way which newest ones appear first, making difficult to follow the conversation if there are lots of replies, as it requires to scroll down to the latest one and then scrolling up while reading adn then scrolling down again to read next comment.

## What is the new behavior?
Replies are ordered on its chronological order: older are shown first and followed by newer ones.

New behavior is also consistent with LBRY.TV and ODYSEE.COM. See for example https://lbry.tv/microsoft:2. Replies from the comments are the bottom are now shown in the same order in both the site and LBRY Android app.