### PR TITLE
Replace Hex class from GMS with the one from Apache

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,6 +119,7 @@ dependencies {
 
     implementation 'com.arthenica:mobile-ffmpeg-full-gpl:4.3.1.LTS'
 
+    implementation 'commons-codec:commons-codec:1.15'
     implementation 'org.bitcoinj:bitcoinj-tools:0.14.7'
     implementation 'org.java-websocket:Java-WebSocket:1.5.1'
 

--- a/app/src/main/java/io/lbry/browser/utils/Helper.java
+++ b/app/src/main/java/io/lbry/browser/utils/Helper.java
@@ -29,9 +29,8 @@ import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.google.android.gms.common.util.Hex;
+import org.apache.commons.codec.binary.Hex;
 
-import org.bitcoinj.core.Base58;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -39,7 +38,7 @@ import org.json.JSONObject;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.DecimalFormat;
@@ -795,9 +794,9 @@ public final class Helper {
     public static String SHA256(String value) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(value.getBytes("UTF-8"));
-            return Hex.bytesToStringLowercase(hash);
-        } catch (NoSuchAlgorithmException | UnsupportedEncodingException ex) {
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return Hex.encodeHexString(hash, true);
+        } catch (NoSuchAlgorithmException ex) {
             return null;
         }
     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-fdroid/issues/6

## What is the current behavior?
Helper imports a whole class from Google Messaging Service just to do some string transformation. That import injects some artifacts from Play Services which cannot be used on FDroid build, although they are required on the regular LBRY Play Store release
## What is the new behavior?
Using the encodeHex method from Apache Commons artifact it is possible to exclude those Play Services injected dependencies without breaking the code.
## Other information
New behavior of SHA256() method HAS NOT BEEN tested.