### PR TITLE
Avoid showing vertical scroll bar on stage error listview

### DIFF
--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -40,6 +40,7 @@ import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.Menu;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
@@ -2749,6 +2750,23 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
         ListView listView = findViewById(R.id.startup_stage_error_listview);
         StartupStageAdapter adapter = new StartupStageAdapter(this, startupStages);
         listView.setAdapter(adapter);
+
+        // Add 1 pixel to listview height
+        int listHeight = Math.round(getResources().getDisplayMetrics().density);
+
+        for (int i = 0; i < startupStages.size(); i++) {
+            View item = adapter.getView(i, null, listView);
+            item.measure(0, 0);
+            listHeight += item.getMeasuredHeight();
+        }
+
+        // Properly set listview height by adding all seven items and the divider heights
+        // and the additional 1 pixel so no vertical scroll bar is shown
+        ViewGroup.LayoutParams params = listView.getLayoutParams();
+        params.height = listHeight + (listView.getCount() + 1) * listView.getDividerHeight();
+        listView.setLayoutParams(params);
+        listView.invalidate();
+        listView.requestLayout();
 
         findViewById(R.id.splash_view_loading_container).setVisibility(View.GONE);
         findViewById(R.id.splash_view_error_container).setVisibility(View.VISIBLE);

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -159,7 +159,7 @@
             <ListView
                 android:id="@+id/startup_stage_error_listview"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 android:layout_marginTop="12dp"
                 android:divider="@android:color/transparent"
                 android:dividerHeight="8dp"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
On some cases it could happen that the list which shows startup stage errors is also showing a scroll bar, which also makes not all stages be seen at the same time
## What is the new behavior?
Listview is measured and resized to a height which would allow all stages statuses to be seen at the same time
## Other information
Testing on the emulators didn't show the current behavior. However, testing on my physical device did show it. I suggest testing this PR on a physical device.

ListView layout_height on app_bar_main.xml was changed to "0dp" as Android Studio was recommending that change.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
