### PR TITLE
Changed wallet send notification to accept 4 digit decimal

### DIFF
--- a/app/src/main/java/io/lbry/browser/ui/wallet/WalletFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/wallet/WalletFragment.java
@@ -463,7 +463,7 @@ public class WalletFragment extends BaseFragment implements SdkStatusListener, W
                 double sentAmount = actualSendAmount;
                 String message = getResources().getQuantityString(
                         R.plurals.you_sent_credits, sentAmount == 1.0 ? 1 : 2,
-                        new DecimalFormat("#,###.##").format(sentAmount));
+                        new DecimalFormat("#,###.####").format(sentAmount));
                 Helper.setViewText(inputSendAddress, null);
                 Helper.setViewText(inputSendAmount, null);
                 if (view != null) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #1086

## What is the current behavior?
Wallet send notification only shows 2 decimals (if present) even though 4 decimal sends are allowed.

## What is the new behavior?
Wallet send notification now shows 4 decimals (if present).
