### PR TITLE
Use Base64 to encode html when rendering Markdown files

### DIFF
--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -15,6 +15,7 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.text.format.DateUtils;
+import android.util.Base64;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -92,8 +93,6 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import io.lbry.browser.MainActivity;
 import io.lbry.browser.R;
@@ -2140,19 +2139,9 @@ public class FileViewFragment extends BaseFragment implements
         ReadTextFileTask task = new ReadTextFileTask(filePath, new ReadTextFileTask.ReadTextFileHandler() {
             @Override
             public void onSuccess(String text) {
-                String html = buildMarkdownHtml(text);
-
                 if (webView != null) {
-                    // Due to a change to Chrome, WebView only displays '#' -and everything after it-
-                    // if it is '%23' instead. Problem appears in text like '#2' or #hashtags.
-                    Pattern pattern = Pattern.compile("#(\\S+)");
-                    Matcher matcher = pattern.matcher(html);
-
-                    if (matcher.find()) {
-                        html = html.replaceAll(pattern.toString(), "&%2335;" + matcher.group(1));
-                    }
-
-                    webView.loadData(html, "text/html", "utf-8");
+                    String html = buildMarkdownHtml(text);
+                    webView.loadData(Base64.encodeToString(html.getBytes(), Base64.NO_PADDING), "text/html", "base64");
                 }
             }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #960 -still partially fixed, don't close it-

## What is the current behavior?
Some problems are still showing up when using the octothorpe character
## What is the new behavior?
New code fixes it by encoding the HTML string using Base64, as recommended by [Google](https://developer.android.com/reference/android/webkit/WebView#loadData(java.lang.String,%20java.lang.String,%20java.lang.String)). Additionally, it no longer requires to run a regex matching, making it faster.
## Testing
Search for "octothorpe-test" on the LBRY Android app and open the one on the "javirid" channel, as it includes some problematic cases. Currently it shows a few problems still. With this PR applied, everything looks fine. Compare it with the rendered Markdown on [LBRY.TV](https://lbry.tv/@javirid:9/octothorpe-test:6)