### PR TITLE
Fix NoSuchMethod exception for HelperSHA256 on API Level prior to P

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,6 +128,8 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
 
     testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 

--- a/app/src/androidTest/java/io/lbry/browser/utils/HelperTest.java
+++ b/app/src/androidTest/java/io/lbry/browser/utils/HelperTest.java
@@ -1,0 +1,15 @@
+package io.lbry.browser.utils;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+@SmallTest
+public class HelperTest {
+    @Test
+    public void SHA256() {
+        assertEquals("de9edb2044d012f04553e49b04d54cbec8e8a46a40ad5a19bc5dcce1da00ecfd", Helper.SHA256(String.valueOf(12345678912345L)));
+    }
+}

--- a/app/src/main/java/io/lbry/browser/utils/Helper.java
+++ b/app/src/main/java/io/lbry/browser/utils/Helper.java
@@ -795,7 +795,11 @@ public final class Helper {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
-            return Hex.encodeHexString(hash, true);
+
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O_MR1)
+                return Hex.encodeHexString(hash, true);
+            else
+                return new String(Hex.encodeHex(hash)).toLowerCase();
         } catch (NoSuchAlgorithmException ex) {
             return null;
         }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: Instrumented test

## What is the current behavior?
On devices running older than Android Pie, an exception will be raised when using Helper.SHA256 method.
## What is the new behavior?
Now code has been splitted so newer versions will run curent code, while older ones will run the patched one.
## Other information
An instrumented test has been added. I was unable to test it on an emulator. Running the test on my physical Android 8.1 (Oreo MR1) device, it is now working as expected.

To run the instrumented test, open the "tests" view on the Project sidebar tab, an click the "Run" icon on the HelperTest.java on the androidTest folder.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
