### PR TITLE
Styling <code> tag for Markdown content

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -58,4 +58,7 @@
 
     <color name="caption">#CAEDB9</color>
     <color name="overlay">#CC333333</color>
+
+    <color name="codeTagText">#E8B692</color>
+    <color name="codeTagBackground">#464B50</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -58,4 +58,7 @@
 
     <color name="caption">#CAEDB9</color>
     <color name="overlay">#CC333333</color>
+
+    <color name="codeTagText">#2E3439</color>
+    <color name="codeTagBackground">#D0E8FF</color>
 </resources>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #960 -partial fix, don't close-

## What is the current behavior?
`<code>` tag is not rendered like on LBRY Desktop or alternative websites
## What is the new behavior?
`<code>` tag is now rendered like in the desktop app, both in light and dark theme.
## Other information
CommonMark offers the possibility of adding attributes to a node. I think this is the way it should be done, instead of embedding the CSS. This way, style is only added when needed. Code to add the style to every tag is only run when required.