### PR TITLE
Add unit test for LbryUri.toTvString

### DIFF
--- a/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
+++ b/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
@@ -113,6 +113,19 @@ public class LbryUriTest {
         assertEquals(expectedForChannel, obtained);
     }
 
+    @Test
+    public void lbryToTvString() {
+        LbryUri obtained = new LbryUri();
+
+        try {
+            obtained = LbryUri.parse("lbry://@lbry#3f/lbryturns4#6",false);
+        } catch (LbryUriException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals("https://lbry.tv/@lbry:3f/lbryturns4:6", obtained.toTvString());
+    }
+
     @NotNull
     private LbryUri sinthesizeExpected() {
         LbryUri expectedForChannel = new LbryUri();


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: Unit test

## Fixes

Issue Number:

## What is the current behavior?
LbryUri.toTvString() lacks its unit test
## What is the new behavior?
Now it ill be possible to test for method to do what it is supposed to do
## Other information
This is related to #1126, but it is not a fix for it. Providing a fix would then not need to run the app on an emulator, as it will only be needed to run the test, which can be done just with the Java Virtual Machine.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
