### PR TITLE
Hide support button and comments consistently with claim tags

### DIFF
--- a/app/src/main/java/io/lbry/browser/ui/channel/ChannelCommentsFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/channel/ChannelCommentsFragment.java
@@ -187,9 +187,21 @@ public class ChannelCommentsFragment extends Fragment implements SdkStatusListen
     private void checkAndLoadComments() {
         View root = getView();
         if (root != null) {
+            View commentsDisabledText = root.findViewById(R.id.channel_disabled_comments);
+            View commentForm = root.findViewById(R.id.container_comment_form);
             RecyclerView commentsList = root.findViewById(R.id.channel_comments_list);
-            if (commentsList == null || commentsList.getAdapter() == null || commentsList.getAdapter().getItemCount() == 0) {
-                loadComments();
+
+            if (claim.getTags().contains("disable-comments")) {
+                Helper.setViewVisibility(commentsDisabledText, View.VISIBLE);
+                Helper.setViewVisibility(commentForm, View.GONE);
+                Helper.setViewVisibility(commentsList, View.GONE);
+            } else {
+                Helper.setViewVisibility(commentsDisabledText, View.GONE);
+                Helper.setViewVisibility(commentForm, View.VISIBLE);
+                Helper.setViewVisibility(commentsList, View.VISIBLE);
+                if (commentsList == null || commentsList.getAdapter() == null || commentsList.getAdapter().getItemCount() == 0) {
+                    loadComments();
+                }
             }
         }
     }

--- a/app/src/main/java/io/lbry/browser/ui/channel/ChannelFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/channel/ChannelFragment.java
@@ -503,6 +503,11 @@ public class ChannelFragment extends BaseFragment implements FetchChannelsListen
         layoutLoadingState.setVisibility(View.GONE);
         layoutDisplayArea.setVisibility(View.VISIBLE);
 
+        if (claim.getTags().contains("disable-support"))
+            buttonTip.setVisibility(View.GONE);
+        else
+            buttonTip.setVisibility(View.VISIBLE);
+
         String thumbnailUrl = claim.getThumbnailUrl();
         String coverUrl = claim.getCoverUrl();
         textTitle.setText(Helper.isNullOrEmpty(claim.getTitle()) ? claim.getName() : claim.getTitle());

--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -1498,7 +1498,7 @@ public class FileViewFragment extends BaseFragment implements
         Helper.setViewVisibility(layoutNothingAtLocation, View.GONE);
 
         if (claim.getTags().contains("disable-support") || claim.getSigningChannel().getTags().contains("disable-support"))
-            Helper.setViewVisibility(tipButton, View.INVISIBLE);
+            Helper.setViewVisibility(tipButton, View.GONE);
         else
             Helper.setViewVisibility(tipButton, View.VISIBLE);
 

--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -210,6 +210,8 @@ public class FileViewFragment extends BaseFragment implements
     private View layoutResolving;
     private int lastPositionSaved;
 
+    private View tipButton;
+
     private WebView webView;
     private boolean webViewAdded;
 
@@ -254,6 +256,8 @@ public class FileViewFragment extends BaseFragment implements
         layoutResolving = root.findViewById(R.id.file_view_loading_container);
         layoutDisplayArea = root.findViewById(R.id.file_view_claim_display_area);
         buttonPublishSomething = root.findViewById(R.id.nothing_at_location_publish_button);
+
+        tipButton = root.findViewById(R.id.file_view_action_tip);
 
         containerReplyToComment = root.findViewById(R.id.comment_form_reply_to_container);
         textReplyingTo = root.findViewById(R.id.comment_form_replying_to_text);
@@ -1493,6 +1497,11 @@ public class FileViewFragment extends BaseFragment implements
         Helper.setViewVisibility(layoutLoadingState, View.GONE);
         Helper.setViewVisibility(layoutNothingAtLocation, View.GONE);
 
+        if (claim.getTags().contains("disable-support") || claim.getSigningChannel().getTags().contains("disable-support"))
+            Helper.setViewVisibility(tipButton, View.INVISIBLE);
+        else
+            Helper.setViewVisibility(tipButton, View.VISIBLE);
+
         loadViewCount();
         checkIsFollowing();
         
@@ -1675,9 +1684,20 @@ public class FileViewFragment extends BaseFragment implements
     private void checkAndLoadComments() {
         View root = getView();
         if (root != null) {
+            View commentsDisabledText = root.findViewById(R.id.file_view_disabled_comments);
+            View commentForm = root.findViewById(R.id.container_comment_form);
             RecyclerView commentsList = root.findViewById(R.id.file_view_comments_list);
-            if (commentsList == null || commentsList.getAdapter() == null || commentsList.getAdapter().getItemCount() == 0) {
-                loadComments();
+            if (claim.getTags().contains("disable-comments") || claim.getSigningChannel().getTags().contains("disable-comments")) {
+                Helper.setViewVisibility(commentsDisabledText, View.VISIBLE);
+                Helper.setViewVisibility(commentForm, View.GONE);
+                Helper.setViewVisibility(commentsList, View.GONE);
+            } else {
+                Helper.setViewVisibility(commentsDisabledText, View.GONE);
+                Helper.setViewVisibility(commentForm, View.VISIBLE);
+                Helper.setViewVisibility(commentsList, View.VISIBLE);
+                if (commentsList == null || commentsList.getAdapter() == null || commentsList.getAdapter().getItemCount() == 0) {
+                    loadComments();
+                }
             }
         }
     }

--- a/app/src/main/res/layout/fragment_channel_comments.xml
+++ b/app/src/main/res/layout/fragment_channel_comments.xml
@@ -28,12 +28,27 @@
             android:orientation="vertical">
 
             <include layout="@layout/container_comment_form"
+                android:id="@+id/container_comment_form"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="0dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
-                android:layout_marginBottom="16dp" />
+                android:layout_marginBottom="16dp"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/channel_disabled_comments"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginTop="8dp"
+                android:fontFamily="@font/inter"
+                android:text="@string/channel_disabled_comments"
+                android:textFontWeight="300"
+                android:textSize="14sp"
+                android:visibility="gone" />
 
             <TextView
                 android:id="@+id/channel_no_comments"

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -845,7 +845,21 @@
                             android:textSize="16sp" />
                     </RelativeLayout>
 
-                    <include layout="@layout/container_comment_form" />
+                    <include layout="@layout/container_comment_form"
+                        android:id="@+id/container_comment_form"/>
+
+                    <TextView
+                        android:id="@+id/file_view_disabled_comments"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16dp"
+                        android:layout_marginTop="8dp"
+                        android:layout_marginEnd="16dp"
+                        android:fontFamily="@font/inter"
+                        android:text="@string/creator_disabled_comments"
+                        android:textFontWeight="300"
+                        android:textSize="14sp"
+                        android:visibility="gone" />
 
                     <TextView
                         android:id="@+id/file_view_no_comments"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,8 @@
     <string name="no_comments">No comments to display at this time.</string>
     <string name="sdk_initializing_comments">Comments will display after the background service is initialized.</string>
     <string name="comment_error">Your comment could not be posted at this time. Please try again later.</string>
+    <string name="channel_disabled_comments">This channel has disabled comments on their page.</string>
+    <string name="creator_disabled_comments">The creator of this content has disabled comments.</string>
     <string name="share_lbry_content">Share LBRY content</string>
     <string name="view">View</string>
     <string name="play">Play</string>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:1146

## What is the current behavior?
See #1146
## What is the new behavior?
See #1146 
## Other information
In comment fragment for channel, the comment form visibility is GONE to avoid it been shown just before being replaced by the texto for channels having comments disabled. This change is not needed for FileViewFragment as this replacement occurs while not in user view.

Two new strings have been added. Text was taken from LBRY.TV. Translation will be needed.

This commit adds code to code which is already been duplicated in various files. This will be fixed in an upcoming PR which replaces comment form with a new widget instead of a layout which should be <included>
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
