### PR TITLE
Allow media to be played automatically

### DIFF
--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -336,6 +336,7 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
 
     // preference keys
     public static final String PREFERENCE_KEY_BACKGROUND_PLAYBACK = "io.lbry.browser.preference.userinterface.BackgroundPlayback";
+    public static final String PREFERENCE_KEY_MEDIA_AUTOPLAY = "io.lbry.browser.preference.userinterface.MediaAutoplay";
     public static final String PREFERENCE_KEY_DARK_MODE = "io.lbry.browser.preference.userinterface.DarkMode";
     public static final String PREFERENCE_KEY_SHOW_MATURE_CONTENT = "io.lbry.browser.preference.userinterface.ShowMatureContent";
     public static final String PREFERENCE_KEY_SHOW_URL_SUGGESTIONS = "io.lbry.browser.preference.userinterface.UrlSuggestions";
@@ -678,6 +679,11 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
     public boolean isBackgroundPlaybackEnabled() {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
         return sp.getBoolean(PREFERENCE_KEY_BACKGROUND_PLAYBACK, true);
+    }
+
+    public boolean isMediaAutoplayEnabled() {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+        return sp.getBoolean(PREFERENCE_KEY_MEDIA_AUTOPLAY, true);
     }
 
     public boolean initialSubscriptionMergeDone() {

--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -291,7 +291,6 @@ public class FileViewFragment extends BaseFragment implements
                     if (!playbackStarted) {
                         logPlay(currentUrl, startTimeMillis);
                         playbackStarted = true;
-                        isPlaying = true;
 
                         long lastPosition = loadLastPlaybackPosition();
                         if (lastPosition > -1) {
@@ -339,6 +338,11 @@ public class FileViewFragment extends BaseFragment implements
                 } else {
                     hideBuffering();
                 }
+            }
+
+            @Override
+            public void onIsPlayingChanged(boolean isPlayng) {
+                isPlaying = isPlayng;
             }
         };
 

--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -12,7 +12,6 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.os.Handler;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.text.format.DateUtils;
@@ -98,6 +97,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -284,7 +284,7 @@ public class FileViewFragment extends BaseFragment implements
 
         fileViewPlayerListener = new Player.EventListener() {
             @Override
-            public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
+            public void onPlaybackStateChanged(@Player.State int playbackState) {
                 if (playbackState == Player.STATE_READY) {
                     elapsedDuration = MainActivity.appPlayer.getCurrentPosition();
                     totalDuration = MainActivity.appPlayer.getDuration() < 0 ? 0 : MainActivity.appPlayer.getDuration();
@@ -303,7 +303,7 @@ public class FileViewFragment extends BaseFragment implements
                     hideBuffering();
 
                     if (loadingNewClaim) {
-                        MainActivity.appPlayer.setPlayWhenReady(true);
+                        MainActivity.appPlayer.setPlayWhenReady(Objects.requireNonNull((MainActivity) (getActivity())).isMediaAutoplayEnabled());
                         loadingNewClaim = false;
                     }
                 } else if (playbackState == Player.STATE_BUFFERING) {
@@ -1762,7 +1762,7 @@ public class FileViewFragment extends BaseFragment implements
                     ((MainActivity) context).setNowPlayingClaim(claim, currentUrl);
                 }
 
-                MainActivity.appPlayer.setPlayWhenReady(true);
+                MainActivity.appPlayer.setPlayWhenReady(Objects.requireNonNull((MainActivity) (getActivity())).isMediaAutoplayEnabled());
                 String userAgent = Util.getUserAgent(context, getString(R.string.app_name));
                 String mediaSourceUrl = getStreamingUrl();
                 MediaSource mediaSource = new ProgressiveMediaSource.Factory(
@@ -1770,7 +1770,8 @@ public class FileViewFragment extends BaseFragment implements
                         new DefaultExtractorsFactory()
                 ).setLoadErrorHandlingPolicy(new StreamLoadErrorPolicy()).createMediaSource(Uri.parse(mediaSourceUrl));
 
-                MainActivity.appPlayer.prepare(mediaSource, true, true);
+                MainActivity.appPlayer.setMediaSource(mediaSource, true);
+                MainActivity.appPlayer.prepare();
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,7 @@
     <string name="user_interface">Content &amp; User interface</string>
     <string name="other">Other</string>
     <string name="enable_background_playback">Enable background playback</string>
+    <string name="enable_autoplay">Autoplay media files</string>
     <string name="enable_dark_mode">Enable dark theme</string>
     <string name="show_mature_content">Show mature content</string>
     <string name="show_url_suggestions">Show URL suggestions</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -11,6 +11,11 @@
             app:title="@string/enable_background_playback"
             app:iconSpaceReserved="false" />
         <SwitchPreferenceCompat
+            app:key="io.lbry.browser.preference.userinterface.MediaAutoplay"
+            app:defaultValue="true"
+            app:title="@string/enable_autoplay"
+            app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
             app:key="io.lbry.browser.preference.userinterface.DarkMode"
             app:title="@string/enable_dark_mode"
             app:iconSpaceReserved="false" />


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #844 

## What is the current behavior?
Video and audio content plays automatically when shown on the detail view
## What is the new behavior?
By default, content will still play when opened, but user will be able to disable the autoplay of media.
## Other information
This PR changes some methods which have been deprecated for ExoPlayer2 API.

A new string has been added for the setting string which is shown on Settings fragment. Translation will be needed. String was copied from LBRY.TV

## Testing

I have been testing it this way:

1. Open a file which hasn't been viewed yet and let it play for some time
2. Open another file from the Related content list which wasn't opened yet
3. Open a file which had already been consumed, preferably a different one from the ones used on previous steps
4. Open a file which hasn't been consumed yet from the Following fragment

This was tested with default setting (=true) and then repeated, with different files or after clearing cache, with setting set to false.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
