### PR TITLE
Move the wallet floating button away when scroll gets to the bottom

### DIFF
--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -1,5 +1,6 @@
 package io.lbry.browser;
 
+import android.animation.ObjectAnimator;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ActivityManager;
@@ -822,6 +823,20 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
 
     public void removeWalletBalanceListener(WalletBalanceListener listener) {
         walletBalanceListeners.remove(listener);
+    }
+
+    public void restoreWalletContainerPosition() {
+        View floatingBalance = findViewById(R.id.floating_balance_main_container);
+
+        ObjectAnimator animation = ObjectAnimator.ofFloat(floatingBalance, "translationY", 0f);
+        animation.setDuration(250).start();
+    }
+
+    public void translateFloatingWallet(float initialY) {
+        if (findViewById(R.id.floating_balance_main_container).getY() == initialY) {
+            ObjectAnimator animation = ObjectAnimator.ofFloat(findViewById(R.id.floating_balance_main_container), "translationY", 2 * findViewById(R.id.floating_balance_main_container).getHeight());
+            animation.setDuration(300).start();
+        }
     }
 
     public void removeNavFragment(Class fragmentClass, int navItemId) {

--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -247,6 +247,8 @@ public class FileViewFragment extends BaseFragment implements
     // if this is set, scroll to the specific comment on load
     private String commentHash;
 
+    private float floatingWalletPositionY;
+
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.fragment_file_view, container, false);
@@ -802,6 +804,7 @@ public class FileViewFragment extends BaseFragment implements
             activity.removeSdkStatusListener(this);
             activity.removeStoragePermissionListener(this);
             activity.removeWalletBalanceListener(this);
+            activity.restoreWalletContainerPosition();
             activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
         }
 
@@ -1281,6 +1284,27 @@ public class FileViewFragment extends BaseFragment implements
         buttonFollow.setOnClickListener(followUnfollowListener);
         buttonUnfollow.setOnClickListener(followUnfollowListener);
         buttonBell.setOnClickListener(bellIconListener);
+
+        NestedScrollView scrollView = root.findViewById(R.id.file_view_scroll_view);
+
+        // Store floating wallet balance vertical position when fragment was created
+        // This is used for animate it when user scrolls to the bottom of the screen
+        View floatingBalance = getActivity().findViewById(R.id.floating_balance_main_container);
+        floatingWalletPositionY = floatingBalance.getY();
+
+        scrollView.setOnScrollChangeListener(new NestedScrollView.OnScrollChangeListener() {
+            @Override
+            public void onScrollChange(NestedScrollView v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+                Context ctx = getContext();
+                if (scrollY < oldScrollY && ctx instanceof MainActivity) {
+                    // User has scrolled upwards
+                    ((MainActivity) ctx).restoreWalletContainerPosition();
+                } else if (scrollY == (v.getChildAt(0).getMeasuredHeight() - v.getMeasuredHeight()) && ctx instanceof MainActivity) {
+                    // User is at the bottom of the screen
+                    ((MainActivity) ctx).translateFloatingWallet(floatingWalletPositionY);
+                }
+            }
+        });
 
         commentChannelSpinnerAdapter = new InlineChannelSpinnerAdapter(getContext(), R.layout.spinner_item_channel, new ArrayList<>());
         commentChannelSpinnerAdapter.addPlaceholder(false);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: partially #1054 (DON'T CLOSE)

## What is the current behavior?
Latest comment or text cannot be read at the bottom of the fragment which shows the content (FileViewFragment)
## What is the new behavior?
Floating balance container will be animated to disappear to the bottom of the screen when user has scroll to the bottom of the screen. When there are no comments and last item is the comment form, the balance will not be animated, as there is enough room to see and interact with the form.

When user scrolls some distance in the upward direction, balance container will be animated again into the screen.
## Other information
The same fix can be applied to channel screen. This will come in another PR, as it requires more time because of the way tabs work in Android
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
