### PR TITLE
Use total wallet balance instead of spendable

### DIFF
--- a/app/src/main/java/io/lbry/browser/adapter/WalletDetailAdapter.java
+++ b/app/src/main/java/io/lbry/browser/adapter/WalletDetailAdapter.java
@@ -1,0 +1,100 @@
+package io.lbry.browser.adapter;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ImageButton;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+
+import java.util.List;
+
+import io.lbry.browser.MainActivity;
+import io.lbry.browser.R;
+import io.lbry.browser.model.WalletDetailItem;
+import io.lbry.browser.utils.Helper;
+import io.lbry.browser.views.CreditsBalanceView;
+
+public class WalletDetailAdapter extends BaseAdapter {
+    private final List<WalletDetailItem> list;
+    private final LayoutInflater inflater;
+
+    public WalletDetailAdapter(Context ctx, List<WalletDetailItem> rows) {
+        this.list = rows;
+        this.inflater = LayoutInflater.from(ctx);
+    }
+    @Override
+    public int getCount() {
+        return list.size();
+    }
+
+    @Override
+    public Object getItem(int i) {
+        return list.get(i);
+    }
+
+    @Override
+    public long getItemId(int i) {
+        return i;
+    }
+
+    @Override
+    public View getView(int i, View view, ViewGroup viewGroup) {
+        if (view == null) {
+            view = inflater.inflate(R.layout.list_item_boosting_balance, viewGroup, false);
+
+            CreditsBalanceView balanceView = view.findViewById(R.id.wallet_supporting_balance);
+            TextView detailTextView = view.findViewById(R.id.detail);
+            TextView detailExplanationTextView = view.findViewById(R.id.detail_explanation);
+
+            WalletDetailItem item = (WalletDetailItem) getItem(i);
+
+            detailTextView.setText(item.detail);
+            detailExplanationTextView.setText(item.detailDesc);
+
+            Helper.setViewText(balanceView, item.detailAmount);
+
+            ProgressBar progressUnlockTips = view.findViewById(R.id.wallet_unlock_tips_progress);
+            progressUnlockTips.setVisibility(item.isInProgress ? View.VISIBLE : View.GONE);
+
+            ImageButton buttonLock = view.findViewById(R.id.lock_button);
+            buttonLock.setVisibility((item.isUnlockable && !item.isInProgress) ? View.VISIBLE : View.GONE);
+
+            if (item.isUnlockable) {
+                buttonLock.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        if (view.getContext() != null) {
+                            AlertDialog.Builder builder = new AlertDialog.Builder(view.getContext()).
+                                    setTitle(R.string.unlock_tips).
+                                    setMessage(R.string.confirm_unlock_tips)
+                                    .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialogInterface, int i) {
+                                            unlockTips(view);
+                                        }
+                                    }).setNegativeButton(R.string.no, null);
+                            builder.show();
+                        }
+                    }
+                });
+            }
+        }
+        return view;
+    }
+
+    private void unlockTips(View v) {
+        Context ctx = v.getContext();
+        if (ctx instanceof MainActivity) {
+            v.setVisibility(View.GONE);
+            View progress = v.getRootView().findViewById(R.id.wallet_unlock_tips_progress);
+            progress.setVisibility(View.VISIBLE);
+            ((MainActivity) ctx).unlockTips();
+        }
+    }
+}

--- a/app/src/main/java/io/lbry/browser/model/WalletDetailItem.java
+++ b/app/src/main/java/io/lbry/browser/model/WalletDetailItem.java
@@ -1,0 +1,17 @@
+package io.lbry.browser.model;
+
+public class WalletDetailItem {
+    public String detail;
+    public String detailDesc;
+    public String detailAmount;
+    public boolean isUnlockable;
+    public boolean isInProgress;
+
+    public WalletDetailItem(String detail, String detailDesc, String detailAmount, boolean isUnlockable, boolean isInProgress) {
+        this.detail = detail;
+        this.detailDesc = detailDesc;
+        this.detailAmount = detailAmount;
+        this.isUnlockable = isUnlockable;
+        this.isInProgress = isInProgress;
+    }
+}

--- a/app/src/main/java/io/lbry/browser/utils/Helper.java
+++ b/app/src/main/java/io/lbry/browser/utils/Helper.java
@@ -77,6 +77,7 @@ public final class Helper {
     public static final String FILE_SIZE_FORMAT_PATTERN = "#,###.#";
     public static final DecimalFormat LBC_CURRENCY_FORMAT = new DecimalFormat(LBC_CURRENCY_FORMAT_PATTERN);
     public static final DecimalFormat FULL_LBC_CURRENCY_FORMAT = new DecimalFormat("#,###.########");
+    public static final DecimalFormat REDUCED_LBC_CURRENCY_FORMAT = new DecimalFormat("#,###.####");
     public static final DecimalFormat SIMPLE_CURRENCY_FORMAT = new DecimalFormat("#,##0.00");
     public static final SimpleDateFormat FILESTAMP_FORMAT =  new SimpleDateFormat("yyyyMMdd_HHmmss");
     public static final String EXPLORER_TX_PREFIX = "https://explorer.lbry.com/tx";

--- a/app/src/main/java/io/lbry/browser/views/CreditsBalanceView.java
+++ b/app/src/main/java/io/lbry/browser/views/CreditsBalanceView.java
@@ -1,0 +1,69 @@
+package io.lbry.browser.views;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.util.DisplayMetrics;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+
+import io.lbry.browser.R;
+
+public class CreditsBalanceView extends TextView {
+    float textFontSize;
+    private float iconSize;
+    Rect r;
+    Paint p;
+
+    public CreditsBalanceView(Context context) {
+        super(context);
+    }
+
+    public CreditsBalanceView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        r = new Rect();
+        p = new Paint();
+
+        TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.CreditsBalanceView,0, 0);
+
+        try {
+            textFontSize = a.getDimension(R.styleable.CreditsBalanceView_textSize, 24f);
+            iconSize = a.getDimension(R.styleable.CreditsBalanceView_iconSize, 20f);
+
+            this.setTextSize((int) textFontSize);
+
+            DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
+            float px = 8 * (metrics.densityDpi / 160f);
+
+            setPadding((int) iconSize + Math.round(px), 0, 0, 0);
+        } finally {
+            a.recycle();
+        }
+
+    }
+
+    @Override
+    protected void onMeasure (int widthMeasureSpec, int heightMeasureSpec){
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+    }
+
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        drawLbryCredits(canvas);
+    }
+
+    private void drawLbryCredits(Canvas c) {
+        @SuppressLint("UseCompatLoadingForDrawables") Drawable icon = getResources().getDrawable(R.drawable.ic_credits, null);
+        float delta = (c.getHeight() - iconSize) / 2;
+        icon.setBounds(0, (int) delta, (int) iconSize, (int) (delta + iconSize));
+        icon.draw(c);
+    }
+}

--- a/app/src/main/res/layout/card_wallet_balance.xml
+++ b/app/src/main/res/layout/card_wallet_balance.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:lbry="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:elevation="4dp">
@@ -8,63 +9,122 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <RelativeLayout
+        <LinearLayout
             android:background="@drawable/stripe_2x"
             android:layout_width="match_parent"
-            android:layout_height="220dp"
-            android:padding="16dp">
-            <TextView
-                android:id="@+id/wallet_balance_title"
-                android:text="@string/balance"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/inter"
-                android:textStyle="bold"
-                android:textColor="@color/white"
-                android:textSize="20sp" />
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/wallet_balance_title"
-                android:layout_marginTop="4dp"
-                android:text="@string/you_currently_have"
-                android:fontFamily="@font/inter"
-                android:textFontWeight="600"
-                android:textColor="@color/caption"
-                android:textSize="16sp" />
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:orientation="vertical">
 
-            <LinearLayout
-                android:layout_width="match_parent"
+            <io.lbry.browser.views.CreditsBalanceView
+                android:id="@+id/wallet_total_balance"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:layout_above="@id/wallet_balance_usd_value">
-                <ImageView
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginEnd="4dp"
-                    android:src="@drawable/ic_credits" />
-                <TextView
-                    android:id="@+id/wallet_balance_value"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:fontFamily="@font/inter"
-                    android:text="@string/zero"
-                    android:textColor="@color/white"
-                    android:textSize="36sp"
-                    android:textFontWeight="300"
-                    />
-            </LinearLayout>
+                lbry:textSize="@dimen/wallet_total_balance_font_size"
+                lbry:iconSize="24dp"
+                android:textColor="@color/white"
+                android:textFontWeight="300" />
+
             <TextView
                 android:id="@+id/wallet_balance_usd_value"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentBottom="true"
                 android:fontFamily="@font/inter"
                 android:textColor="@color/white"
                 android:textSize="16sp"
                 android:textFontWeight="300" />
-        </RelativeLayout>
+
+            <TextView
+                android:id="@+id/total_balance_desc"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="@font/inter"
+                android:textColor="@color/white"
+                android:textFontWeight="300"
+                android:textSize="@dimen/wallet_detail_balance_desc_font_size" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                android:background="@color/lightDivider" />
+
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+                <io.lbry.browser.views.CreditsBalanceView
+                    android:id="@+id/wallet_spendable_balance"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    lbry:textSize="@dimen/wallet_detail_balance_font_size"
+                    lbry:iconSize="14dp"
+                    android:textColor="@color/white"
+                    android:textFontWeight="300" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="bottom"
+                    android:fontFamily="@font/inter"
+                    android:paddingStart="8dp"
+                    android:text="@string/immediately_spendable"
+                    android:textColor="@color/white"
+                    android:textFontWeight="300"
+                    android:textSize="@dimen/wallet_detail_balance_desc_font_size" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal">
+                <io.lbry.browser.views.CreditsBalanceView
+                    android:id="@+id/wallet_supporting_balance"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    lbry:textSize="@dimen/wallet_detail_balance_font_size"
+                    lbry:iconSize="14dp"
+                    android:textColor="@color/white"
+                    android:textFontWeight="300" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/inter"
+                    android:paddingStart="8dp"
+                    android:text="@string/boosting_content"
+                    android:textColor="@color/white"
+                    android:textFontWeight="300"
+                    android:textSize="@dimen/wallet_detail_balance_desc_font_size" />
+
+                <TextView
+                    android:id="@+id/view_more_button"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="18dp"
+                    android:drawableEnd="@drawable/ic_arrow_dropdown"
+                    android:gravity="end"
+                    android:text="@string/view_more"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/wallet_detail_balance_font_size" />
+            </LinearLayout>
+
+            <ListView
+                android:id="@+id/balance_detail_listview"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="8dp"
+                android:visibility="gone">
+
+            </ListView>
+
+
+
+        </LinearLayout>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/wallet_buy_lbc_button"
@@ -107,192 +167,6 @@
             android:layout_marginBottom="16dp"
             android:background="@color/lightDivider" />
 
-        <LinearLayout
-            android:weightSum="2"
-            android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp">
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <io.lbry.browser.ui.controls.SolidIconView
-                    android:text="@string/fa_gift"
-                    android:layout_width="18dp"
-                    android:layout_height="18dp"
-                    android:textColor="@color/lbryGreen" />
-                <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_marginStart="4dp"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/inter"
-                        android:text="@string/you_also_have"
-                        android:textSize="14sp"
-                        android:textFontWeight="600"
-                        />
-
-                    <LinearLayout
-                        android:orientation="horizontal"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content">
-                        <ImageView
-                            android:layout_width="14dp"
-                            android:layout_height="14dp"
-                            android:layout_gravity="center_vertical"
-                            android:src="@drawable/ic_credits"
-                            android:layout_marginEnd="4dp" />
-                        <TextView
-                            android:id="@+id/wallet_balance_tips"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:fontFamily="@font/inter"
-                            android:text="0"
-                            android:textSize="24sp" />
-                    </LinearLayout>
-
-                    <TextView
-                        android:id="@+id/wallet_balance_tips_usd_value"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/inter"
-                        android:textFontWeight="300"
-                        android:textSize="14sp" />
-
-                    <RelativeLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="16dp">
-                        <TextView
-                            android:id="@+id/wallet_in_tips_label"
-                            android:layout_centerVertical="true"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:fontFamily="@font/inter"
-                            android:text="@string/in_tips"
-                            android:textSize="14sp" />
-                        <TextView
-                            android:id="@+id/wallet_unlock_tips_link"
-                            android:background="?attr/selectableItemBackground"
-                            android:clickable="true"
-                            android:layout_centerVertical="true"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_toEndOf="@id/wallet_in_tips_label"
-                            android:fontFamily="@font/inter"
-                            android:layout_marginStart="24dp"
-                            android:text="@string/unlock"
-                            android:textColor="@color/lbryGreen"
-                            android:textSize="14sp"
-                            android:visibility="gone" />
-                        <ProgressBar
-                            android:id="@+id/wallet_unlock_tips_progress"
-                            android:layout_centerVertical="true"
-                            android:layout_width="16dp"
-                            android:layout_height="16dp"
-                            android:layout_marginStart="24dp"
-                            android:layout_toEndOf="@id/wallet_in_tips_label"
-                            android:visibility="gone" />
-
-                    </RelativeLayout>
-
-                    <TextView
-                        android:id="@+id/wallet_hint_earn_more_tips"
-                        android:clickable="true"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
-                        android:fontFamily="@font/inter"
-                        android:text="@string/earn_more_tips"
-                        android:textColor="@color/lbryGreen"
-                        android:textSize="14sp" />
-                </LinearLayout>
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <io.lbry.browser.ui.controls.SolidIconView
-                    android:text="@string/fa_lock"
-                    android:layout_width="18dp"
-                    android:layout_height="18dp"
-                    android:textColor="@color/lbryGreen" />
-                <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_marginStart="4dp"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/inter"
-                        android:text="@string/you_staked"
-                        android:textSize="14sp"
-                        android:textFontWeight="600"
-                        />
-
-                    <LinearLayout
-                        android:orientation="horizontal"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content">
-                        <ImageView
-                            android:layout_width="14dp"
-                            android:layout_height="14dp"
-                            android:layout_gravity="center_vertical"
-                            android:src="@drawable/ic_credits"
-                            android:layout_marginEnd="4dp" />
-                        <TextView
-                            android:id="@+id/wallet_balance_staked_publishes"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:fontFamily="@font/inter"
-                            android:text="0"
-                            android:textSize="24sp" />
-                    </LinearLayout>
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/inter"
-                        android:text="@string/in_your_publishes"
-                        android:textSize="14sp" />
-
-                    <LinearLayout
-                        android:orientation="horizontal"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp">
-                        <ImageView
-                            android:layout_width="14dp"
-                            android:layout_height="14dp"
-                            android:layout_gravity="center_vertical"
-                            android:src="@drawable/ic_credits"
-                            android:layout_marginEnd="4dp" />
-                        <TextView
-                            android:id="@+id/wallet_balance_staked_supports"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:fontFamily="@font/inter"
-                            android:text="0"
-                            android:textSize="24sp" />
-                    </LinearLayout>
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/inter"
-                        android:text="@string/in_your_supports"
-                        android:textSize="14sp" />
-                </LinearLayout>
-            </LinearLayout>
-        </LinearLayout>
 
         <LinearLayout
             android:background="@color/lbryGreen"

--- a/app/src/main/res/layout/list_item_boosting_balance.xml
+++ b/app/src/main/res/layout/list_item_boosting_balance.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:lbry="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/relativeLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="16dp">
+
+    <TextView
+        android:id="@+id/detail"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:textColor="@color/white"
+        android:textSize="12sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/detail_explanation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:textColor="@color/white"
+        android:textSize="12sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/detail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/wallet_unlock_tips_progress"
+        android:layout_width="16dp"
+        android:layout_height="match_parent"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="8dp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toStartOf="@id/wallet_supporting_balance" />
+
+    <ImageButton
+        android:id="@+id/lock_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:background="@android:color/transparent"
+        android:src="@drawable/ic_lock"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/wallet_supporting_balance"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <io.lbry.browser.views.CreditsBalanceView
+        android:id="@+id/wallet_supporting_balance"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:textColor="@color/white"
+        lbry:iconSize="18dp"
+        lbry:textSize="@dimen/wallet_detail_balance_font_size" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -252,15 +252,8 @@
 
     <!-- Wallet -->
     <string name="balance">Balans</string>
-    <string name="you_currently_have">U het tans</string>
     <string name="convert_credits">U kan u krediete in USD omskakel en die omgeskakelde bedrag met \'n uitruil onttrek. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Skakel krediete na USD op Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Jy het ook</string>
-    <string name="you_staked">Jy het vasgehou</string>
-    <string name="in_tips">in wenke</string>
-    <string name="in_your_publishes">in u publikasies</string>
-    <string name="in_your_supports">in u steun</string>
-    <string name="earn_more_tips">Verdien meer wenke deur cool video\'s op te laai</string>
     <string name="sdk_still_initializing">Die agtergronddiens word steeds geïnitialiseer. U kan die inhoud intussen verken en kyk.</string>
     <string name="sdk_initializing_functionality">U kan dit nie nou doen nie, want die agtergronddiens is nog besig om te initialiseer.</string>
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -265,15 +265,8 @@
 
     <!-- Wallet -->
     <string name="balance">Balanç</string>
-    <string name="you_currently_have">Ara tens</string>
     <string name="convert_credits">Pots convertir els teus crèdits a USD i retirar la quantitat convertida emprant un intercanvi. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Aprèn-ne més&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Converteix crèdits a USD a Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">També tens</string>
-    <string name="you_staked">Has invertit</string>
-    <string name="in_tips">en propines</string>
-    <string name="in_your_publishes">en les teves publicacions</string>
-    <string name="in_your_supports">en els teus suports</string>
-    <string name="earn_more_tips">Obtén més propines pujant vídeos genials</string>
     <string name="sdk_initializing">El servei en segon pla s\'està inicialitzant...</string>
     <string name="sdk_still_initializing">El servei en segon pla encara s\'està inicialitzant. Pots explorar i veure contingut mentrestant.</string>
     <string name="sdk_initializing_functionality">No pots fer això ara perquè el servei en segon pla encara s\'està inicialitzant.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -256,15 +256,8 @@ Bitte versuche es später erneut.</string>
 
     <!-- Wallet -->
     <string name="balance">Kontostand</string>
-    <string name="you_currently_have">Sie haben derzeit</string>
     <string name="convert_credits">Sie können Ihr Guthaben in USD umrechnen und den umgerechneten Betrag über einen Umtausch abheben. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Sie haben auch</string>
-    <string name="you_staked">Sie haben gesteckt</string>
-    <string name="in_tips">in Trinkgeldern</string>
-    <string name="in_your_publishes">in Deinen Veröffentlichungen</string>
-    <string name="in_your_supports">in Deinen Unterstützungen</string>
-    <string name="earn_more_tips">Verdienen Sie weitere Tipps, indem Sie coole Videos hochladen</string>
     <string name="sdk_still_initializing">Der Hintergrunddienst wird noch initialisiert. In der Zwischenzeit können Sie Inhalte erkunden und ansehen.</string>
     <string name="sdk_initializing_functionality">Sie können dies derzeit nicht tun, da der Hintergrunddienst noch initialisiert wird.</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -265,15 +265,8 @@
 
     <!-- Wallet -->
     <string name="balance">Saldo</string>
-    <string name="you_currently_have">Tu Actualmente tienes</string>
     <string name="convert_credits">Puede convertir sus créditos a USD y retirar el monto convertido mediante un intercambio. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Aprender más&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convierta créditos a USD en Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">También tienes</string>
-    <string name="you_staked">En stake</string>
-    <string name="in_tips">en propinas </string>
-    <string name="in_your_publishes">en tus publicaciones</string>
-    <string name="in_your_supports">en tus propinas</string>
-    <string name="earn_more_tips">Obtenga más propinas al subir videos geniales</string>
     <string name="sdk_initializing">El servicio en segundo plano se está iniciando...</string>
     <string name="sdk_still_initializing">El servicio en segundo plano aún se está iniciando. Puede explorar y ver contenido mientras tanto.</string>
     <string name="sdk_initializing_functionality">No puede hacer esto ahora porque el servicio en segundo plano todavía no está iniciado.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -221,15 +221,8 @@
 
     <!-- Wallet -->
     <string name="balance">Saldo</string>
-    <string name="you_currently_have">Hetkel on sul</string>
     <string name="convert_credits">Valuutavahetustes saad vahetada oma LBC raha USD vastu ja selle välja võtta. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Loe lisa&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Valuutavahetus Bittrex LBC > USD&lt;/a&gt;</string>
-    <string name="you_also_have">Lisaks on sul</string>
-    <string name="you_staked">Sul on panused</string>
-    <string name="in_tips">jootrahana</string>
-    <string name="in_your_publishes">sinu postitustes</string>
-    <string name="in_your_supports">sinu toetustes</string>
-    <string name="earn_more_tips">Teeni lisapreemiaid laadides üles huvitavaid videosid</string>
     <string name="sdk_still_initializing">Taustateenus veel stardib. Võid seniks postitusi sirvida.</string>
     <string name="sdk_initializing_functionality">Seda ei saa hetkel teha, kuna taustateenus pole veel käivitunud.</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -265,15 +265,8 @@
 
     <!-- Wallet -->
     <string name="balance">Solde</string>
-    <string name="you_currently_have">Vous avez actuellement</string>
     <string name="convert_credits">Vous pouvez convertir vos crédits en USD et retirer le montant converti à l\'aide d\'un échange. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Vous avez aussi</string>
-    <string name="you_staked">Tu as jalonné</string>
-    <string name="in_tips">En pourboires</string>
-    <string name="in_your_publishes">dans vos publications</string>
-    <string name="in_your_supports">dans vos supports</string>
-    <string name="earn_more_tips">Obtenez plus de pourboire en téléchargeant des vidéos sympas</string>
     <string name="sdk_initializing">Le service d\'arrière-plan est en cours d\'initialisation…</string>
     <string name="sdk_still_initializing">Le service d\'arrière-plan est toujours en cours d\'initialisation. Vous pouvez explorer et regarder du contenu en attendant.</string>
     <string name="sdk_initializing_functionality">Vous ne pouvez pas le faire pour le moment car le service d\'arrière-plan est toujours en cours d\'initialisation.</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -252,15 +252,8 @@
 
     <!-- Wallet -->
     <string name="balance">બેલેન્સ</string>
-    <string name="you_currently_have">તમારી પાસે હાલમાં</string>
     <string name="convert_credits">તમે તમારા ક્રેડિટને USD માં કન્વર્ટ કરી શકો છો અને એક્સચેંજનો ઉપયોગ કરીને રૂપાંતરિત રકમ પાછા ખેંચી શકો છો. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">તમારી પાસે પણ છે</string>
-    <string name="you_staked">તમે સ્ટેક્ડ</string>
-    <string name="in_tips">ટીપ્સમાં</string>
-    <string name="in_your_publishes">તમારા પ્રકાશનોમાં</string>
-    <string name="in_your_supports">તમારા સપોર્ટ</string>
-    <string name="earn_more_tips">કૂલ વિડિઓઝ અપલોડ કરીને વધુ ટીપ્સ કમાઓ</string>
     <string name="sdk_still_initializing">પૃષ્ઠભૂમિ સેવા હજી પ્રારંભ થઈ રહી છે. તમે સરેરાશ સમયમાં અન્વેષણ કરી શકો છો અને સામગ્રી જોઈ શકો છો.</string>
     <string name="sdk_initializing_functionality">તમે હમણાં આ કરી શકતા નથી કારણ કે પૃષ્ઠભૂમિ સેવા હજી પ્રારંભ થઈ રહી છે.</string>
 

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -281,15 +281,8 @@
 
     <!-- Wallet -->
     <string name="balance">מאזן</string>
-    <string name="you_currently_have">יש לך כרגע</string>
     <string name="convert_credits">ביכולתך להמיר את הקרדיט שלך ל-USD ולמשוך את הסכום המומר באמצעות חלפניה. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;למדו עוד&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;המר קרדיט ל-USD באתר Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">יש לך גם</string>
-    <string name="you_staked">השקעת</string>
-    <string name="in_tips">בטיפים</string>
-    <string name="in_your_publishes">בפרסומים שלך</string>
-    <string name="in_your_supports">בפעולות תמיכה</string>
-    <string name="earn_more_tips">הרווח יותר טיפים ע\"י העלאת סרטונים מגניבים</string>
     <string name="sdk_initializing">תהליך הרקע כרגע מתאתחל…</string>
     <string name="sdk_still_initializing">תהליך הרקע כרגע מתאתחל. אתה יכול לבצע סקירה ולצפות בתכנים בינתיים.</string>
     <string name="sdk_initializing_functionality">אינך יכול לבצע זאת בינתיים משום שתהליך הרקע עדיין מתאתחל.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -265,15 +265,8 @@
 
     <!-- Wallet -->
     <string name="balance">बैलेंस</string>
-    <string name="you_currently_have">आपके पास अभी है</string>
     <string name="convert_credits"> आप अपने क्रेडिटस को यूसडी में बदल सकते हैं और उन्हें एक्सचेंज की मदद से निकाल भी सकते हैं। &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt; क्रेडिटस को यूसडी में बदलें बिट्रिक्स पर&lt;/a&gt;</string>
-    <string name="you_also_have">  आपके पास और भी है</string>
-    <string name="you_staked">आपने स्टेक की है</string>
-    <string name="in_tips">टिप्स में</string>
-    <string name="in_your_publishes">आपकी पब्लिशिस में हैं</string>
-    <string name="in_your_supports">आपके सपोर्ट्स में हैं</string>
-    <string name="earn_more_tips">मनोरंजक वीडियोस अपलोड करके और अधिक टिप्स कमाए</string>
     <string name="sdk_initializing">पृष्ठभूमि सेवा प्रारंभ कर रहा है ...</string>
     <string name="sdk_still_initializing">पृष्ठभूमि सेवाएं अभी भी शुरू हो रही है। इस दौरान आप अन्य सामग्री को खोज एवं देख सकते हैं।</string>
     <string name="sdk_initializing_functionality">आप यह अभी नहीं कर सकते हैं क्योंकि पृष्ठभूमि सेवाएं अभी भी शुरू हो रही है</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -257,15 +257,8 @@
 
     <!-- Wallet -->
     <string name="balance">Saldo</string>
-    <string name="you_currently_have">Anda sekarang punya</string>
     <string name="convert_credits">Anda dapat mengonversi kredit Anda ke USD dan menarik jumlah yang dikonversi menggunakan pertukaran. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Kamu juga punya</string>
-    <string name="you_staked">Anda mempertaruhkan</string>
-    <string name="in_tips">dalam tips</string>
-    <string name="in_your_publishes">di publikasi Anda</string>
-    <string name="in_your_supports">dalam dukungan Anda</string>
-    <string name="earn_more_tips">Hasilkan lebih banyak tips dengan mengunggah video keren</string>
     <string name="sdk_initializing">Layanan latar belakang sedang menginisialisasi...</string>
     <string name="sdk_still_initializing">Layanan latar belakang masih diinisialisasi. Anda dapat menjelajahi dan menonton konten dalam waktu yang bersamaan.</string>
     <string name="sdk_initializing_functionality">Anda tidak dapat melakukan ini sekarang karena layanan latar belakang masih diinisialisasi.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -265,15 +265,8 @@
 
     <!-- Wallet -->
     <string name="balance">Saldo</string>
-    <string name="you_currently_have">Hai attualmente</string>
     <string name="convert_credits">Puoi convertire i tuoi crediti in USD e trasferire il valore convertito utilizzando un cambio. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Vedi altro&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Converti crediti in USD su Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Hai anche</string>
-    <string name="you_staked">Hai accumulato</string>
-    <string name="in_tips">in donaziones</string>
-    <string name="in_your_publishes">nelle tue pubblicazioni</string>
-    <string name="in_your_supports">nei tuoi supporti</string>
-    <string name="earn_more_tips">Guadagna altre donazioni caricando video interessanti</string>
     <string name="sdk_initializing">Avvio servizio in background...</string>
     <string name="sdk_still_initializing">Il servizio in background è ancora in avvio. Puoi esplorare e visualizzare contenuti nel frattempo.</string>
     <string name="sdk_initializing_functionality">Non puoi fare questo al momento perché il servizio in background è ancora in avviamento.</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -257,15 +257,8 @@
 
     <!-- Wallet -->
     <string name="balance">Duwitmu</string>
-    <string name="you_currently_have">Sampeyan saiki duwe</string>
     <string name="convert_credits">Sampeyan bisa ngowahi kridit sampeyan menyang USD lan mbatalake jumlah sing diowahi nggunakake ijol-ijolan. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Sampeyan yo duwe</string>
-    <string name="you_staked">Sampeyan naruhno</string>
-    <string name="in_tips">ing tips</string>
-    <string name="in_your_publishes">ing nerbitake sampeyan</string>
-    <string name="in_your_supports">ing dhukungan sampeyan</string>
-    <string name="earn_more_tips">Entuk tips liyane kanthi ngunggah video sing viral</string>
     <string name="sdk_initializing">Miwiti Layanan latar mburi...</string>
     <string name="sdk_still_initializing">Layanan latar mburi isih miwiti. Sampeyan bisa njelajah lan nonton konten ing wektu tegese.</string>
     <string name="sdk_initializing_functionality">Sampeyan ora bisa nindakake iki saiki amarga layanan latar mburi isih miwiti.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -258,15 +258,8 @@ Sila kembali sebentar lagi.</string>
 
     <!-- Wallet -->
     <string name="balance">Baki</string>
-    <string name="you_currently_have">Anda kini mempunyai</string>
     <string name="convert_credits">Anda boleh menukar kredit anda ke USD dan keluarkan jumlah tersebut menerusi sebuah bursa. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Tukar kredit ke USD dengan Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Anda juga mempunyai</string>
-    <string name="you_staked">Anda mempertaruhkan</string>
-    <string name="in_tips">dalam tips</string>
-    <string name="in_your_publishes">dalam terbitan anda</string>
-    <string name="in_your_supports">dalam sokongan anda</string>
-    <string name="earn_more_tips">Dapatkan lebih banyak tips dengan memuat-naik video yang menarik</string>
     <string name="sdk_initializing">Servis latar belakang sedang diinisialisasi...</string>
     <string name="sdk_still_initializing">Servis latar belakang masih diinisialisasi. Anda boleh meneroka dan menonton kandungan dalam masa yang sama.</string>
     <string name="sdk_initializing_functionality">Anda tidak dapat melakukan ini sekarang kerana servis latar belakang masih diinisialisasi.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -252,15 +252,8 @@
 
     <!-- Wallet -->
     <string name="balance">Balans</string>
-    <string name="you_currently_have">U hebt momenteel</string>
     <string name="convert_credits">U kunt uw tegoeden omzetten in USD en het omgerekende bedrag opnemen met een omwisseling. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">U hebt ook</string>
-    <string name="you_staked">U hebt ingezet</string>
-    <string name="in_tips">in fooien</string>
-    <string name="in_your_publishes">in uw publicaties</string>
-    <string name="in_your_supports">in uw steunen</string>
-    <string name="earn_more_tips">Verdien meer fooien door coole video\'s te uploaden</string>
     <string name="sdk_still_initializing">De achtergrondservice wordt nog geïnitialiseerd. U kunt ondertussen inhoud verkennen en bekijken.</string>
     <string name="sdk_initializing_functionality">U kunt dit nu niet doen omdat de achtergrondservice nog steeds wordt geïnitialiseerd.</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -281,15 +281,8 @@
 
     <!-- Wallet -->
     <string name="balance">Balans</string>
-    <string name="you_currently_have">Obecnie posiadasz</string>
     <string name="convert_credits">Możesz zamienić swoje kredyty na USD i wypłacić przeliczoną kwotę za pomocą giełdy. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Posiadasz również</string>
-    <string name="you_staked">Zestackowane</string>
-    <string name="in_tips">w napiwkach</string>
-    <string name="in_your_publishes">w twoich publikacjach</string>
-    <string name="in_your_supports">w twoich wsparciach</string>
-    <string name="earn_more_tips">Zarób więcej napiwków publikując fajne filmiki</string>
     <string name="sdk_initializing">Usługa w tle jest inicjowana...</string>
     <string name="sdk_still_initializing">Usługa w tle jest nadal inicjowana. W międzyczasie możesz eksplorować i oglądać treści.</string>
     <string name="sdk_initializing_functionality">Nie możesz tego teraz zrobić, ponieważ usługa w tle wciąż się inicjuje.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -265,15 +265,8 @@
 
     <!-- Wallet -->
     <string name="balance">Saldo</string>
-    <string name="you_currently_have">Você tem atualmente</string>
     <string name="convert_credits">Você pode converter seus créditos em USD e retirar o valor convertido usando uma exchange. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Saiba mais&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Converter creditos para USD no Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Você também tem</string>
-    <string name="you_staked">Você investiu</string>
-    <string name="in_tips">em gorjetas</string>
-    <string name="in_your_publishes">nas suas publicções</string>
-    <string name="in_your_supports">Nos seus apoios</string>
-    <string name="earn_more_tips">Ganhe mais gorjetas enviando vídeos legais</string>
     <string name="sdk_initializing">O serviço de segundo plano está sendo inicializado....</string>
     <string name="sdk_still_initializing">O serviço de segundo plano ainda está sendo inicializado. Você pode explorar conteúdos incríveis nesse meio tempo.</string>
     <string name="sdk_initializing_functionality">Você não pode fazer isso agora porque o serviço de segundo plano ainda está sendo inicializado.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -265,15 +265,8 @@
 
     <!-- Wallet -->
     <string name="balance">Saldo</string>
-    <string name="you_currently_have">Atualmente você tem</string>
     <string name="convert_credits">Você pode converter seus créditos em dólares americanos e retirar o valor convertido usando uma exchange. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Você também tem</string>
-    <string name="you_staked">Você acumulou</string>
-    <string name="in_tips">em gorjetas</string>
-    <string name="in_your_publishes">nas suas publicações</string>
-    <string name="in_your_supports">nos seus apoios</string>
-    <string name="earn_more_tips">Ganhe mais gorjetas enviando videos legais</string>
     <string name="sdk_initializing">O serviço em segundo plano está inicializando...</string>
     <string name="sdk_still_initializing">O serviço em segundo plano ainda está sendo inicializado. Você pode explorar e assistir ao conteúdo nesse meio tempo.</string>
     <string name="sdk_initializing_functionality">Você não pode fazer isso agora porque o serviço em segundo plano ainda está sendo inicializado.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -260,15 +260,8 @@
 
     <!-- Wallet -->
     <string name="balance">Sold</string>
-    <string name="you_currently_have">Acum ai</string>
     <string name="convert_credits">Îţi poţi converti creditele în USD şi să retragi suma folosind o casă de schimb. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Detalii&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Schimbă creditele în USD la Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Mai ai și</string>
-    <string name="you_staked">Ai depus</string>
-    <string name="in_tips">în bacşişuri</string>
-    <string name="in_your_publishes">în publicările tale</string>
-    <string name="in_your_supports">în susţinerile tale</string>
-    <string name="earn_more_tips">Câştigă mai multe bacşişuri publicând conţinut</string>
     <string name="sdk_still_initializing">Serviciul din fundal încă se iniţializează. Poţi explora şi vedea conţinut între timp.</string>
     <string name="sdk_initializing_functionality">Nu poţi face asta acum deoarce serviciul din fundal încă se iniţializează.</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -281,15 +281,8 @@
 
     <!-- Wallet -->
     <string name="balance">Баланс</string>
-    <string name="you_currently_have">У Вас сейчас есть </string>
     <string name="convert_credits">Вы можете поменять кредиты на доллары США и снять сумму, используя обменник. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">У Вас также есть</string>
-    <string name="you_staked">У Вас сохранено</string>
-    <string name="in_tips">в чаевых</string>
-    <string name="in_your_publishes">в Ваших публикациях</string>
-    <string name="in_your_supports">в Ваших поддержках</string>
-    <string name="earn_more_tips">Заработайте больше чаевых, загружая крутые видео</string>
     <string name="sdk_initializing">Фоновый сервис запускается...</string>
     <string name="sdk_still_initializing">Фоновый сервис всё ещё запускается. Между тем Вы уже можете искать и смотреть какой-либо контент.</string>
     <string name="sdk_initializing_functionality">Вы не можете сделать это прямо сейчас, потому что фоновый сервис всё ещё запускается.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -273,15 +273,8 @@
 
     <!-- Wallet -->
     <string name="balance">Balans</string>
-    <string name="you_currently_have">Trenutno imate</string>
     <string name="convert_credits">Možete konvertovati vaše kredite u USD i unovčiti konvertovani iznos koristeći menjačnicu. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Takođje imate</string>
-    <string name="you_staked">Vi štedite</string>
-    <string name="in_tips">u tipovima</string>
-    <string name="in_your_publishes">u vašim objavama</string>
-    <string name="in_your_supports">u vašim podrškama</string>
-    <string name="earn_more_tips">Zaradi više tipova tako što ćeš objaviti  što više cool video klipova</string>
     <string name="sdk_initializing">Pozadinski servis se pokreće...</string>
     <string name="sdk_still_initializing">Pokretanje pozadinskog servisa je i dalje u toku. Za to vreme možete istraživati i gledati sadržaje.</string>
     <string name="sdk_initializing_functionality">Ne možete uraditi ovo za vreme učitavanja pozadinskog servisa.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -252,15 +252,8 @@
 
     <!-- Wallet -->
     <string name="balance">Bakiye</string>
-    <string name="you_currently_have">Şuna sahipsiniz</string>
     <string name="convert_credits">Kredilerinizi USD\'ye çevirebilir ve döviz hizmeti ile paranızı çekebilirsiniz. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Şunlara da sahipsiniz</string>
-    <string name="you_staked">Ayırdığınız miktar</string>
-    <string name="in_tips">bahşiş olarak</string>
-    <string name="in_your_publishes">yayınlarınızda mevcut olan</string>
-    <string name="in_your_supports">desteklerinizde mevcut olan</string>
-    <string name="earn_more_tips">Daha havalı videolar yükleyerek daha çok bahşiş kazan</string>
     <string name="sdk_still_initializing">Arkaplan servisi hala başlatılıyor. Bu arada siz içerikleri keşfedebilir ve izleyebilirsiniz.</string>
     <string name="sdk_initializing_functionality">Bunu şu an yapamazsınız çünkü arkaplan servisi hala başlatılıyor.</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -268,15 +268,8 @@
 
     <!-- Wallet -->
     <string name="balance">Рахунок </string>
-    <string name="you_currently_have">У Вас зараз є</string>
     <string name="convert_credits">Ви можете обміняти кредити на долари США та зняти ці гроші за допомогою обміннику. &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">У Вас також є</string>
-    <string name="you_staked">Ви стейкнули </string>
-    <string name="in_tips">в чайових</string>
-    <string name="in_your_publishes">у Ваших публікаціях</string>
-    <string name="in_your_supports">у Ваших підтримках</string>
-    <string name="earn_more_tips">Заробляйте більше чайових, завантажуючи класні відео</string>
     <string name="sdk_still_initializing">Фоновий сервіс все ще ініціалізується. Ви можете шукати та переглядати у цей час.</string>
     <string name="sdk_initializing_functionality">Ви не можете публікувати контент прямо зараз, тому що фоновий сервіс все ще ініціалізується.</string>
 

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -245,15 +245,8 @@
 
     <!-- Wallet -->
     <string name="balance">Tài khoản</string>
-    <string name="you_currently_have">Bạn hiện có</string>
     <string name="convert_credits">Bạn có thể chuyển đổi tín dụng của mình sang USD và rút số tiền đã chuyển đổi bằng cách sử dụng một trao đổi.  &lt;a href=\"https://lbry.com/faq/exchanges\"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;Đổi LBC sang USD tại Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">Bạn cũng có</string>
-    <string name="you_staked">Bạn đặt cược</string>
-    <string name="in_tips">in tips</string>
-    <string name="in_your_publishes">trong nội dung của bạn</string>
-    <string name="in_your_supports">trong sự hỗ trợ của bạn</string>
-    <string name="earn_more_tips">Kiếm thêm tiền bằng cách tải lên các video thú vị</string>
     <string name="sdk_still_initializing">Dịch vụ nền vẫn đang khởi tạo. Bạn có thể khám phá và xem nội dung trong thời gian trung bình.</string>
     <string name="sdk_initializing_functionality">Bạn không thể làm điều này ngay bây giờ vì dịch vụ nền vẫn đang khởi tạo.</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -257,15 +257,8 @@
 
     <!-- Wallet -->
     <string name="balance">餘額</string>
-    <string name="you_currently_have">你目前有</string>
     <string name="convert_credits">你可以把信用額兌換為美元然後到交易所提取。&lt;a href=\"https://lbry.com/faq/exchanges\"&gt;了解更多&lt;/a&gt;。</string>
     <string name="convert_credits_bittrex">&lt;a href=\"https://bittrex.com/Account/Register?referralCode=4M1-P30-BON\"&gt;在Bittrex上轉換美元&lt;/a&gt;</string>
-    <string name="you_also_have">你同時有</string>
-    <string name="you_staked">你累計</string>
-    <string name="in_tips">於小費</string>
-    <string name="in_your_publishes">為發佈押金</string>
-    <string name="in_your_supports">你支持的內容</string>
-    <string name="earn_more_tips">上傳酷酷的影片以獲得更多小費</string>
     <string name="sdk_initializing">背景程式執行初始化中……</string>
     <string name="sdk_still_initializing">背景程式仍在初始化。與此同時，你可以探索和觀看內容。</string>
     <string name="sdk_initializing_functionality">你目前還不能執行這動作，因為背景程式仍在初始化。</string>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="CreditsBalanceView">
+        <attr name="textSize" format="dimension" />
+        <attr name="iconSize" format="dimension" />
+        <attr name="amount" format="string" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,4 +5,7 @@
     <dimen name="nav_header_vertical_spacing">8dp</dimen>
     <dimen name="nav_header_height">176dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
+    <dimen name="wallet_total_balance_font_size">14sp</dimen>
+    <dimen name="wallet_detail_balance_font_size">12sp</dimen>
+    <dimen name="wallet_detail_balance_desc_font_size">12sp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -277,15 +277,19 @@
 
     <!-- Wallet -->
     <string name="balance">Balance</string>
-    <string name="you_currently_have">You currently have</string>
+    <string name="your_total_balance">Your total balance.</string>
+    <string name="all_of_this_is_yours">Your total balance. All of this is yours, but some credits are in use on channels and content right now.</string>
     <string name="convert_credits">You can convert your credits to USD and withdraw the converted amount using an exchange. &lt;a href="https://lbry.com/faq/exchanges"&gt;Learn more&lt;/a&gt;.</string>
     <string name="convert_credits_bittrex">&lt;a href="https://bittrex.com/Account/Register?referralCode=4M1-P30-BON"&gt;Convert credits to USD on Bittrex&lt;/a&gt;</string>
-    <string name="you_also_have">You also have</string>
-    <string name="you_staked">You staked</string>
-    <string name="in_tips">in tips</string>
-    <string name="in_your_publishes">in your publishes</string>
-    <string name="in_your_supports">in your supports</string>
-    <string name="earn_more_tips">Earn more tips by uploading cool videos</string>
+    <string name="immediately_spendable">immediately spendable</string>
+    <string name="boosting_content">boosting content</string>
+    <string name="view_more">View more</string>
+    <string name="earned_from_others">…earned from others</string>
+    <string name="on_initial_publishes">…on initial publishes</string>
+    <string name="supporting_content">…supporting content</string>
+    <string name="unlock_to_spend">(Unlock to spend)</string>
+    <string name="delete_or_edit_past_content">(Delete or edit past content to spend)</string>
+    <string name="delete_supports_to_spend">(Delete supports to spend)</string>
     <string name="sdk_initializing">The background service is initializing…</string>
     <string name="sdk_still_initializing">The background service is still initializing. You can explore and watch content in the mean time.</string>
     <string name="sdk_initializing_functionality">You cannot do this right now because the background service is still initializing.</string>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #1147 

## What is the current behavior?
Spendable wallet balance is shown instead of total one
## What is the new behavior?
Now total wallet balance will be shown. Also the breakdown is shown in a expandable view which will animate a little bit when expanding.
## Other information
A new custom view to show LBRY Credits has been created. This is mostly only usable on the wallet fragment, but it reduces complexity on the layout files as they only need a single widget to be added or edited instead of a couple of them. Also the view can now be edited only once and will be updated wherever it would be used.

Balance breakdown has been implemented as a listview. This way, new items can be added as a Java object instead of using hard-coded views on the balance layout.