### PR TITLE
Enable phone verification

### DIFF
--- a/app/src/main/java/io/lbry/browser/VerificationActivity.java
+++ b/app/src/main/java/io/lbry/browser/VerificationActivity.java
@@ -204,15 +204,16 @@ public class VerificationActivity extends FragmentActivity implements SignInList
             } else if (flow == VERIFICATION_FLOW_REWARDS) {
                 User user = Lbryio.currentUser;
                 // disable phone verification for now
-                /*if (!user.isIdentityVerified()) {
+                if (!user.isIdentityVerified()) {
                     // phone number verification required
                     viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_PHONE, false);
                     flowHandled = true;
-                } else */
-                if (!user.isRewardApproved()) {
-                    // manual verification required
-                    viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_MANUAL, false);
-                    flowHandled = true;
+                } else {
+                    if (!user.isRewardApproved()) {
+                        // manual verification required
+                        viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_MANUAL, false);
+                        flowHandled = true;
+                    }
                 }
             }
 
@@ -223,6 +224,11 @@ public class VerificationActivity extends FragmentActivity implements SignInList
                 return;
             }
         }
+    }
+
+    public void showPhoneVerification() {
+        ViewPager2 viewPager = findViewById(R.id.verification_pager);
+        viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_PHONE, false);
     }
 
     public void showLoading() {
@@ -238,8 +244,12 @@ public class VerificationActivity extends FragmentActivity implements SignInList
 
     @Override
     public void onBackPressed() {
-        // ignore back press
-        return;
+        ViewPager2 viewPager = findViewById(R.id.verification_pager);
+
+        if (viewPager.getCurrentItem() != VerificationPagerAdapter.PAGE_VERIFICATION_MANUAL)
+            viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_MANUAL);
+        else
+            super.onBackPressed();
     }
 
     public void onEmailAdded(String email) {
@@ -296,20 +306,18 @@ public class VerificationActivity extends FragmentActivity implements SignInList
                     ViewPager2 viewPager = findViewById(R.id.verification_pager);
                     // for rewards, (show phone verification if not done, or manual verification if required)
                     if (flow == VERIFICATION_FLOW_REWARDS) {
-                        // skipping phone verification
-                        /*if (!user.isIdentityVerified()) {
+                        if (!user.isIdentityVerified()) {
                             // phone number verification required
                             viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_PHONE, false);
-                        } else
-                        */
-                        if (!user.isRewardApproved()) {
-
-                            // manual verification required
-                            viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_MANUAL, false);
                         } else {
-                            // fully verified
-                            setResult(RESULT_OK);
-                            finish();
+                            if (!user.isRewardApproved()) {
+                                // manual verification required
+                                viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_MANUAL, false);
+                            } else {
+                                // fully verified
+                                setResult(RESULT_OK);
+                                finish();
+                            }
                         }
                     } else if (flow == VERIFICATION_FLOW_WALLET) {
                         // for wallet sync, if password unlock is required, show password entry page
@@ -347,6 +355,7 @@ public class VerificationActivity extends FragmentActivity implements SignInList
                     return;
                 }
 
+                findViewById(R.id.verification_close_button).setVisibility(View.VISIBLE);
                 // show manual verification page if the user is still not reward approved
                 ViewPager2 viewPager = findViewById(R.id.verification_pager);
                 viewPager.setCurrentItem(VerificationPagerAdapter.PAGE_VERIFICATION_MANUAL, false);

--- a/app/src/main/java/io/lbry/browser/ui/verification/ManualVerificationFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/verification/ManualVerificationFragment.java
@@ -21,6 +21,7 @@ import com.google.android.material.snackbar.Snackbar;
 
 import io.lbry.browser.MainActivity;
 import io.lbry.browser.R;
+import io.lbry.browser.VerificationActivity;
 import io.lbry.browser.listener.SignInListener;
 import io.lbry.browser.model.TwitterOauth;
 import io.lbry.browser.model.lbryinc.RewardVerified;
@@ -95,6 +96,13 @@ public class ManualVerificationFragment extends Fragment {
                         }
                     });
                 }
+            }
+        });
+
+        root.findViewById(R.id.verification_manual_phone_number_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                ((VerificationActivity) getContext()).showPhoneVerification();
             }
         });
 

--- a/app/src/main/res/layout/fragment_verification_manual.xml
+++ b/app/src/main/res/layout/fragment_verification_manual.xml
@@ -68,6 +68,33 @@
                 android:fontFamily="@font/inter"
                 android:text="@string/twitter_verify" />
 
+
+            <TextView
+                android:textSize="20sp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="36dp"
+                android:fontFamily="@font/inter"
+                android:text="@string/phone_number_verification"
+                android:textColor="@color/white"
+                android:textFontWeight="300" />
+            <TextView
+                android:textSize="16sp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:fontFamily="@font/inter"
+                android:text="@string/phone_number_verification_desc"
+                android:textColor="@color/white"
+                android:textFontWeight="300" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/verification_manual_phone_number_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:fontFamily="@font/inter"
+                android:text="@string/phone_number_verify" />
+
             <TextView
                 android:textSize="20sp"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,6 +452,9 @@
     <string name="twitter_verification">Twitter Verification</string>
     <string name="twitter_verification_desc">Get instantly verified using your Twitter account. Your Twitter email address must match the email that you provided and your account should be active.</string>
     <string name="twitter_verify">Verify with Twitter</string>
+    <string name="phone_number_verification">Phone Number Verification</string>
+    <string name="phone_number_verification_desc">Get instantly verified using your phone number.</string>
+    <string name="phone_number_verify">Verify with phone number</string>
     <string name="skip_queue_verification">Skip the Queue</string>
     <string name="skip_queue_verification_desc">Skip the manual verification queue by paying a fee in order to start participating in the rewards program immediately.</string>
     <string name="skip_queue_manual_check">If you previously completed a purchase successfully and you still see this screen, please tap the verify purchase button below.</string>


### PR DESCRIPTION
Show the Close button after phone number has been verified

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature
- [x] Code style update (formatting)

## Fixes

Issue Number: #1085 

## What is the current behavior?
No way to verify account other than Twitter, Discord chat or paying fee
## What is the new behavior?
Now it is also possible to be verified using the user mobile phone number
## Other information
This PR adds some strings which should be translated.

Adds a button to the manual verification fragment. When user clicks on it, a new fragment shows, asking user to introduce its phone number. Then a SMS is send to it, which user should introduce inte the fragment. If it matches, the fragment closes. Until #1167 is fixed, the next fragment shown to user is the verification fragment again.

This PR also re-activates the onBackPressed() callback, to allow user to go back when Verifying Phone Number fragment is in the foreground. The cross image will close the full verification fragment. User would prefer to go from one method to another one -from mobile phone to Twitter account, for example-.