### PR TITLE
Use ':' as separator for LBRY.TV sharing links

### DIFF
--- a/app/src/main/java/io/lbry/browser/utils/LbryUri.java
+++ b/app/src/main/java/io/lbry/browser/utils/LbryUri.java
@@ -223,7 +223,10 @@ public class LbryUri {
         String secondaryClaimId = !Helper.isNullOrEmpty(secondaryClaimName) ? streamClaimId : null;
 
         if (!Helper.isNullOrEmpty(primaryClaimId)) {
-            sb.append('#').append(primaryClaimId);
+            if (protocol.equals(LBRY_TV_BASE_URL))
+                sb.append(':').append(primaryClaimId);
+            else
+                sb.append('#').append(primaryClaimId);
         } else if (primaryClaimSequence > 0) {
             sb.append(':').append(primaryClaimSequence);
         } else if (primaryBidPosition > 0) {
@@ -235,7 +238,10 @@ public class LbryUri {
         }
 
         if (!Helper.isNullOrEmpty(secondaryClaimId)) {
-            sb.append('#').append(secondaryClaimId);
+            if (protocol.equals(LBRY_TV_BASE_URL))
+                sb.append(':').append(secondaryClaimId);
+            else
+                sb.append('#').append(secondaryClaimId);
         } else if (secondaryClaimSequence > 0) {
             sb.append(':').append(secondaryClaimSequence);
         } else  if (secondaryBidPosition > 0) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1126 

## What is the current behavior?
Unit test for toTvString() fails
## What is the new behavior?
Unit test for toTvString() no longer fails. This is the method used for getting a sharing link, so when the unit test succeeds, the sharing link should be ok