### PR TITLE
Don't show link to Bittrex

### DIFF
--- a/app/src/main/res/layout/card_wallet_balance.xml
+++ b/app/src/main/res/layout/card_wallet_balance.xml
@@ -155,6 +155,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:layout_marginStart="16dp"
+            android:visibility="gone"
             android:fontFamily="@font/inter"
             android:text="@string/convert_credits_bittrex"
             android:textColorLink="@color/lbryGreen"


### PR DESCRIPTION
This fix uses two services:

- The geolocation API service from LBRY for filtering users not on North-America
- IP-API.com service when the LBRY service returns user is in North-America

This way users not on North-America won't see their IPs sent to a third-party provider.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1179 

## What is the current behavior?
For IPs on the US, users are shown a message about using Bittrex to exchange LBRY Credits to USD. Bittrex is no longer allowing that for users in the US, but LBRY Android users are going to see the message
## What is the new behavior?
Message is not being shown
## Other information
By default, the message is not shown. Then, depending on the IP of the user, it is programmatically made visible. Network requests are using Java Future, because AsyncTask is now deprecated and Java Future works on all supported Android API levels.