### PR TITLE
Fix crash for anonymous content or without tags

### DIFF
--- a/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/io/lbry/browser/ui/findcontent/FileViewFragment.java
@@ -1523,7 +1523,7 @@ public class FileViewFragment extends BaseFragment implements
         Helper.setViewVisibility(layoutLoadingState, View.GONE);
         Helper.setViewVisibility(layoutNothingAtLocation, View.GONE);
 
-        if (claim.getTags().contains("disable-support") || claim.getSigningChannel().getTags().contains("disable-support"))
+        if ((claim.getTags() != null && claim.getTags().contains("disable-support")) || (claim.getSigningChannel() != null && claim.getSigningChannel().getTags().contains("disable-support")))
             Helper.setViewVisibility(tipButton, View.GONE);
         else
             Helper.setViewVisibility(tipButton, View.VISIBLE);
@@ -1713,7 +1713,7 @@ public class FileViewFragment extends BaseFragment implements
             View commentsDisabledText = root.findViewById(R.id.file_view_disabled_comments);
             View commentForm = root.findViewById(R.id.container_comment_form);
             RecyclerView commentsList = root.findViewById(R.id.file_view_comments_list);
-            if (claim.getTags().contains("disable-comments") || claim.getSigningChannel().getTags().contains("disable-comments")) {
+            if ((claim.getTags() != null && (claim.getTags().contains("disable-comments")) || (claim.getSigningChannel() != null && claim.getSigningChannel().getTags().contains("disable-comments")))) {
                 Helper.setViewVisibility(commentsDisabledText, View.VISIBLE);
                 Helper.setViewVisibility(commentForm, View.GONE);
                 Helper.setViewVisibility(commentsList, View.GONE);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1189 

## What is the current behavior?
App crashes when user tries to consume anonymous content -and potentially content without tags-
## What is the new behavior?
A check has been introduced to avoid the crash and show the content