### PR TITLE
Accept colon or octoshape as claimID modifier character

### DIFF
--- a/app/src/main/java/io/lbry/browser/utils/LbryUri.java
+++ b/app/src/main/java/io/lbry/browser/utils/LbryUri.java
@@ -141,20 +141,6 @@ public class LbryUri {
         boolean isChannel = includesChannel && Helper.isNullOrEmpty(possibleStreamName);
         String channelName = includesChannel && streamOrChannelName.length() > 1 ? streamOrChannelName.substring(1) : null;
 
-        /*
-         * It would have thrown already on the RegEx parser if protocol value was incorrect
-         * or HTTPS host was unknown to us.
-         *
-         * [https://] hosts use ':' as ModSeparators while [lbry://] protocol expects '#'
-         */
-
-        if (!components.get(1).isEmpty()) {
-            if (primaryModSeparator.equals(":"))
-                primaryModSeparator = "#";
-            if (secondaryModSeparator.equals(":"))
-                secondaryModSeparator = "#";
-        }
-
         if (includesChannel) {
             if (Helper.isNullOrEmpty(channelName)) {
                 throw new LbryUriException("No channel name after @.");
@@ -329,9 +315,9 @@ public class LbryUri {
                     throw new LbryUriException(String.format("No modifier provided after separator %s", modSeparator));
                 }
 
-                if ("#".equals(modSeparator)) {
+                if ("#".equals(modSeparator) || ":".equals(modSeparator)) {
                     claimId = modValue;
-                } else if (":".equals(modSeparator)) {
+                } else if ("*".equals(modSeparator)) {
                     claimSequence = Helper.parseInt(modValue, -1);
                 } else if ("$".equals(modSeparator)) {
                     bidPosition = Helper.parseInt(modValue, -1);

--- a/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
+++ b/app/src/test/java/io/lbry/browser/utils/LbryUriTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 
 public class LbryUriTest {
     private LbryUri expected;
+    private LbryUri expectedOctoshape;
 
     /*
      * Create an LbryUri object and assign fields manually using class methods. This object will be
@@ -18,14 +19,21 @@ public class LbryUriTest {
     @Before
     public void createExpected() {
         expected = new LbryUri();
+        expectedOctoshape = new LbryUri();
         expected.setChannelName("@lbry");
         expected.setStreamName("lbryturns4");
+        expectedOctoshape.setChannelName("@lbry");
+        expectedOctoshape.setStreamName("lbryturns4");
 
         try {
-            LbryUri.UriModifier primaryMod = LbryUri.UriModifier.parse("#", "3f");
-            LbryUri.UriModifier secondaryMod = LbryUri.UriModifier.parse("#", "6");
+            LbryUri.UriModifier primaryMod = LbryUri.UriModifier.parse(":", "3f");
+            LbryUri.UriModifier secondaryMod = LbryUri.UriModifier.parse(":", "6");
+            LbryUri.UriModifier primaryModOctoshape = LbryUri.UriModifier.parse("#", "3f");
+            LbryUri.UriModifier secondaryModOctoshape = LbryUri.UriModifier.parse("#", "6");
             expected.setChannelClaimId(primaryMod.getClaimId());
             expected.setStreamClaimId(secondaryMod.getClaimId());
+            expectedOctoshape.setChannelClaimId(primaryModOctoshape.getClaimId());
+            expectedOctoshape.setStreamClaimId(secondaryModOctoshape.getClaimId());
         } catch (LbryUriException e) {
             e.printStackTrace();
         }
@@ -71,7 +79,7 @@ public class LbryUriTest {
     }
 
     @Test
-    public void parseLbryProtocolWithChannel() {
+    public void parseLbryProtocolWithChannelOctoshape() {
         LbryUri obtained = new LbryUri();
 
         try {
@@ -80,12 +88,12 @@ public class LbryUriTest {
             e.printStackTrace();
         }
 
-        assertEquals(expected, obtained);
+        assertEquals(expectedOctoshape, obtained);
     }
 
     @Test
     public void parseLbryProtocolOnlyChannel() {
-        LbryUri expectedForChannel = sinthesizeExpected();
+        LbryUri expectedForChannel = sinthesizeExpectedChannelOctoshape();
 
         LbryUri obtained = new LbryUri();
 
@@ -100,7 +108,7 @@ public class LbryUriTest {
 
     @Test
     public void parseLbryTvProtocolOnlyChannel() {
-        LbryUri expectedForChannel = sinthesizeExpected();
+        LbryUri expectedForChannel = sinthesizeExpectedChannelOctoshape();
 
         LbryUri obtained = new LbryUri();
 
@@ -192,7 +200,7 @@ public class LbryUriTest {
     }
 
     @NotNull
-    private LbryUri sinthesizeExpected() {
+    private LbryUri sinthesizeExpectedChannelOctoshape() {
         LbryUri expectedForChannel = new LbryUri();
         expectedForChannel.setChannelName("@UCBerkeley");
         expectedForChannel.setChannel(true);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #1053 

## What is the current behavior?
It replaces colon with octoshape character
## What is the new behavior?
Accepts both colon and octoshape as modifiers for claimIDs while changing accepted sequence number modifier to an asterisk as noted on spec.lbry.com URL section