### PR TITLE
fix null pointer dereference in class Claim

### DIFF
--- a/app/src/main/java/io/lbry/browser/model/Claim.java
+++ b/app/src/main/java/io/lbry/browser/model/Claim.java
@@ -384,10 +384,12 @@ public class Claim {
             long feeAmount = searchResultObject.isNull("fee") ? 0 : searchResultObject.getLong("fee");
             String releaseTimeString = !searchResultObject.isNull("release_time") ? searchResultObject.getString("release_time") : null;
             long releaseTime = 0;
-            try {
-                releaseTime = Double.valueOf(new SimpleDateFormat(RELEASE_TIME_DATE_FORMAT).parse(releaseTimeString).getTime() / 1000.0).longValue();
-            } catch (ParseException ex) {
-                // pass
+            if (releaseTimeString != null) {
+                try {
+                    releaseTime = Double.valueOf(new SimpleDateFormat(RELEASE_TIME_DATE_FORMAT).parse(releaseTimeString).getTime() / 1000.0).longValue();
+                } catch (ParseException ex) {
+                    // pass
+                }
             }
 
             GenericMetadata metadata = (duration > 0 || releaseTime > 0 || feeAmount > 0) ? new StreamMetadata() : new GenericMetadata();


### PR DESCRIPTION
releaseTimeString can be initialized to null.  Check for this case before
trying to parse it.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [ x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ x] I have checked that this PR does not introduce a breaking change
- [ x] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
Application crashes when playing some videos.
## What is the new behavior?
Application continues even if release time string is not found.
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
