### PR TITLE
Add intent filter for odysee.com links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data android:scheme="https" android:host="open.lbry.com"/>
+                <data android:scheme="https" android:host="odysee.com"/>
                 <data android:scheme="https" android:host="lbry.tv" android:pathPattern="/..*/*" />
                 <data android:scheme="https" android:host="lbry.tv" android:pathPattern="/.*:.*" />
                 <data android:scheme="https" android:host="lbry.tv" android:pathPattern="/.*#.*" />

--- a/app/src/main/java/io/lbry/browser/utils/LbryUri.java
+++ b/app/src/main/java/io/lbry/browser/utils/LbryUri.java
@@ -24,7 +24,7 @@ public class LbryUri {
     public static final int CLAIM_ID_MAX_LENGTH = 40;
 
     private static final String REGEX_PART_PROTOCOL = "^((?:lbry://|https://)?)";
-    private static final String REGEX_PART_HOST = "((?:open.lbry.com/|lbry.tv/|lbry.lat/|lbry.fr/|lbry.in/)?)";
+    private static final String REGEX_PART_HOST = "((?:open.lbry.com/|odysee.com/|lbry.tv/|lbry.lat/|lbry.fr/|lbry.in/)?)";
     private static final String REGEX_PART_STREAM_OR_CHANNEL_NAME = "([^:$#/]*)";
     private static final String REGEX_PART_MODIFIER_SEPARATOR = "([:$#]?)([^/]*)";
     private static final String QUERY_STRING_BREAKER = "^([\\S]+)([?][\\S]*)";


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 1209

## What is the current behavior?
It can open links from a couple of variants lbry urls

## What is the new behavior?
It will offer to open links from odysee.com

## Other information

Tested on a Pixel 3 with the following url
https://odysee.com/@Coldfusion:f/toyota-reveals-solid-state-battery:8
twitter integration and google services were disabled.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
