### PR TITLE
Fix media controls notification showing disambiguation drawer

### DIFF
--- a/app/src/main/java/io/lbry/browser/MainActivity.java
+++ b/app/src/main/java/io/lbry/browser/MainActivity.java
@@ -2083,7 +2083,9 @@ public class MainActivity extends AppCompatActivity implements SdkStatusListener
         @Override
         public PendingIntent createCurrentContentIntent(Player player) {
             if (nowPlayingClaimUrl != null) {
-                Intent launchIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(nowPlayingClaimUrl));
+                Intent launchIntent = new Intent(MainActivity.this, MainActivity.class);
+                launchIntent.setAction(Intent.ACTION_VIEW);
+                launchIntent.setData(Uri.parse(nowPlayingClaimUrl));
                 launchIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
                 return PendingIntent.getActivity(MainActivity.this, 0, launchIntent, 0);
             }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Clicking media controls notification show disambiguation drawer with LBRY and Odysee apps available.

## What is the new behavior?

Directly open Odysee MainActivity when clicking media controls notification.

Use direct intent to MainActivity instead of deep link intent.
